### PR TITLE
Revamp: markdown-driven SPA with blog routing

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,1031 @@
+#!/usr/bin/env python3
+"""
+build.py  —  Compile all markdown content into a single SPA index.html
+
+Usage:
+    python build.py
+
+Reads:
+    content/            ← all section markdown files
+    posts/upcoming.md   ← upcoming writing items
+    posts/*.md          ← blog post frontmatter (for manifest)
+    css/portfolio.css   ← base styles (inlined into output)
+
+Writes:
+    index.html          ← compiled SPA (overwritten each run)
+    posts/index.json    ← blog manifest (also updated)
+"""
+
+import glob
+import json
+import os
+import re
+from pathlib import Path
+
+BASE = Path(__file__).parent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def parse_fm(text: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter + body. Handles key:val and key:\\n  - list."""
+    m = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)", text, re.DOTALL)
+    if not m:
+        return {}, text.strip()
+    fm_raw, body = m.group(1), m.group(2).strip()
+
+    fm: dict = {}
+    lines = fm_raw.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        if ":" in stripped and not stripped.startswith("-") and not stripped.startswith(" "):
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if val == "":
+                # collect list items that follow
+                lst = []
+                i += 1
+                while i < len(lines) and re.match(r"^\s*-\s+", lines[i]):
+                    lst.append(re.sub(r"^\s*-\s+", "", lines[i]).strip().strip('"').strip("'"))
+                    i += 1
+                fm[key] = lst
+                continue
+            else:
+                fm[key] = val
+        i += 1
+
+    return fm, body
+
+
+def esc(s: str) -> str:
+    return (
+        str(s)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def md_inline(text: str) -> str:
+    """Convert inline markdown and common typographic shortcuts to HTML."""
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"\*(.+?)\*", r"<em>\1</em>", text)
+    text = re.sub(r"`(.+?)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[(.+?)\]\((.+?)\)", r'<a href="\2">\1</a>', text)
+    text = text.replace(" — ", " &mdash; ").replace("—", "&mdash;")
+    text = text.replace("·", "&middot;").replace("×", "&times;")
+    return text
+
+
+def md_to_html(text: str) -> str:
+    """Convert basic block markdown (headings, lists, paragraphs) to HTML."""
+    lines = text.split("\n")
+    out: list[str] = []
+    in_ul = False
+    in_ol = False
+    para_buf: list[str] = []
+
+    def flush_para() -> None:
+        nonlocal para_buf
+        if not para_buf:
+            return
+        joined = " ".join(para_buf).strip()
+        para_buf = []
+        if not joined:
+            return
+        # italic-only paragraph → muted footnote
+        if re.match(r"^\*.+\*$", joined):
+            out.append(f'<p class="pf-research-more">{md_inline(joined)}</p>')
+        else:
+            out.append(f"<p>{md_inline(joined)}</p>")
+
+    def close_list() -> None:
+        nonlocal in_ul, in_ol
+        if in_ul:
+            out.append("</ul>")
+            in_ul = False
+        if in_ol:
+            out.append("</ol>")
+            in_ol = False
+
+    for line in lines:
+        s = line.strip()
+        if s.startswith("### "):
+            flush_para(); close_list()
+            out.append(f"<h3>{md_inline(s[4:])}</h3>")
+        elif s.startswith("## "):
+            flush_para(); close_list()
+            out.append(f"<h2>{md_inline(s[3:])}</h2>")
+        elif s.startswith("# "):
+            flush_para(); close_list()
+            out.append(f"<h1>{md_inline(s[2:])}</h1>")
+        elif re.match(r"^\d+\.\s", s):
+            flush_para()
+            if not in_ol:
+                close_list()
+                out.append("<ol>")
+                in_ol = True
+            out.append(f"<li>{md_inline(re.sub(r'^\\d+\\.\\s+', '', s))}</li>")
+        elif s.startswith("- ") or s.startswith("* "):
+            flush_para()
+            if not in_ul:
+                close_list()
+                out.append("<ul>")
+                in_ul = True
+            out.append(f"<li>{md_inline(s[2:])}</li>")
+        elif s == "" or re.match(r"^-{3,}$", s):
+            flush_para(); close_list()
+        else:
+            close_list()
+            # skip HTML-comment lines
+            if not s.startswith("<!--"):
+                para_buf.append(s)
+
+    flush_para(); close_list()
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Section builders
+# ---------------------------------------------------------------------------
+
+def build_hero() -> str:
+    fm, body = parse_fm(read(BASE / "content/hero.md"))
+
+    headline = re.sub(r"\*(.+?)\*", r"<em>\1</em>", fm.get("headline", ""))
+
+    # Sub-text: join paragraphs, convert inline markdown
+    paras = [p.strip() for p in body.split("\n\n") if p.strip()]
+    sub_html = " ".join(md_inline(p) for p in paras)
+
+    # Metrics (m1_count … m4_count)
+    metrics_html = ""
+    for n in range(1, 5):
+        count = esc(fm.get(f"m{n}_count", "0"))
+        suffix = esc(fm.get(f"m{n}_suffix", ""))
+        label = esc(fm.get(f"m{n}_label", ""))
+        metrics_html += f"""    <div class="pf-metric">
+      <div class="pf-metric-value"><span data-count="{count}">0</span><span class="counter-suffix">{suffix}</span></div>
+      <div class="pf-metric-label">{label}</div>
+    </div>\n"""
+
+    eyebrow = esc(fm.get("eyebrow", ""))
+    cv_href = esc(fm.get("cv_href", "files/SMAITY_short_CV.pdf"))
+
+    return f"""<header class="pf-hero pf-wrap" id="hero" data-nav>
+  <div class="pf-hero-eyebrow hero-anim hero-anim-1">{eyebrow}</div>
+  <h1 class="pf-hero-headline hero-anim hero-anim-2">{headline}</h1>
+  <p class="pf-hero-sub hero-anim hero-anim-3">{sub_html}</p>
+  <div class="pf-hero-buttons hero-anim hero-anim-4">
+    <a href="{cv_href}" class="pf-btn pf-btn-fill" target="_blank" rel="noopener">Download CV</a>
+    <a href="#writing" class="pf-btn pf-btn-ghost">Read my writing</a>
+    <a href="#contact" class="pf-btn pf-btn-ghost">Get in touch</a>
+  </div>
+  <div class="pf-metrics hero-anim hero-anim-5">
+{metrics_html}  </div>
+</header>"""
+
+
+def build_work() -> str:
+    idx_fm, _ = parse_fm(read(BASE / "content/work/_index.md"))
+    label = esc(idx_fm.get("label", "01 &mdash; Current focus"))
+    title = esc(idx_fm.get("title", "What I am building now"))
+
+    cards = []
+    for path in sorted(glob.glob(str(BASE / "content/work/*.md"))):
+        if "_index" in path:
+            continue
+        fm, body = parse_fm(read(Path(path)))
+        featured = fm.get("featured", "false").lower() == "true"
+        cls = "pf-work-card featured" if featured else "pf-work-card"
+        # Strip HTML comments from body
+        body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).strip()
+        cards.append(f"""    <div class="{cls}">
+      <div class="pf-work-card-label">{esc(fm.get("label", ""))}</div>
+      <h3>{esc(fm.get("title", ""))}</h3>
+      <p>{md_inline(body_clean)}</p>
+    </div>""")
+
+    return f"""<section class="pf-section pf-wrap reveal" id="work" data-nav>
+  <div class="pf-section-label">{label}</div>
+  <h2 class="pf-section-title">{title}</h2>
+  <div class="pf-work-grid">
+{chr(10).join(cards)}
+  </div>
+</section>"""
+
+
+def build_recognition() -> str:
+    fm, body = parse_fm(read(BASE / "content/recognition.md"))
+    label = fm.get("label", "02 &mdash; Recognition")
+    title = fm.get("title", "Recognition")
+
+    items_html = ""
+    for line in body.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("<!--"):
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 3:
+            continue
+        year = esc(parts[0])
+        name = esc(parts[1])
+        org = esc(parts[2])
+        latest = len(parts) > 3 and parts[3].upper() == "LATEST"
+        badge = ' <span class="pf-badge-latest">Latest</span>' if latest else ""
+        items_html += f"""    <li class="pf-recog-item">
+      <span class="pf-recog-year">{year}</span>
+      <span class="pf-recog-name">{name}{badge}</span>
+      <span class="pf-recog-org">{org}</span>
+    </li>\n"""
+
+    return f"""<section class="pf-section pf-wrap reveal" id="recognition" data-nav>
+  <div class="pf-section-label">{esc(label)}</div>
+  <h2 class="pf-section-title">{esc(title)}</h2>
+  <ul class="pf-recog-list">
+{items_html}  </ul>
+</section>"""
+
+
+def parse_upcoming() -> str:
+    """Parse posts/upcoming.md → writing list HTML."""
+    path = BASE / "posts/upcoming.md"
+    if not path.exists():
+        return ""
+
+    _, body = parse_fm(read(path))
+    # Remove HTML comments
+    body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).strip()
+
+    items_html = ""
+    num = 0
+    blocks = re.split(r"^###\s+", body, flags=re.MULTILINE)
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        num += 1
+        lines = block.split("\n")
+        title = lines[0].strip()
+
+        desc_lines = []
+        tag_line = ""
+        for ln in lines[1:]:
+            ln = ln.strip()
+            if not ln:
+                continue
+            if re.match(r"^\[.+?\]", ln):
+                tag_line = ln
+            else:
+                desc_lines.append(ln)
+
+        desc = " ".join(desc_lines)
+        tags = re.findall(r"\[(.+?)\]", tag_line)
+
+        pills_html = ""
+        for tag in tags:
+            if tag.lower() in ("coming-soon", "coming soon"):
+                pills_html += '<span class="pf-pill pf-pill-soon">Coming soon</span>'
+            else:
+                pills_html += f'<span class="pf-pill">{esc(tag)}</span>'
+
+        items_html += f"""    <li class="pf-writing-item">
+      <span class="pf-writing-num">{num:02d}</span>
+      <div>
+        <div class="pf-writing-title">{md_inline(title)}</div>
+        <div class="pf-writing-desc">{md_inline(desc)}</div>
+        <div class="pf-writing-pills">{pills_html}</div>
+      </div>
+      <span class="pf-writing-arrow">&nearr;</span>
+    </li>\n"""
+
+    return items_html
+
+
+def build_writing() -> str:
+    upcoming_html = parse_upcoming()
+    return f"""<section class="pf-section pf-wrap reveal" id="writing" data-nav>
+  <div class="pf-section-label">03 &mdash; Writing</div>
+  <h2 class="pf-section-title">Writing</h2>
+  <ul class="pf-writing-list">
+{upcoming_html}  </ul>
+  <div style="margin-top:2rem;text-align:center">
+    <a href="#blog" class="pf-btn pf-btn-ghost" id="view-all-blog">View all blog posts &rarr;</a>
+  </div>
+</section>"""
+
+
+def build_research() -> str:
+    cols_html = ""
+    for path in sorted(glob.glob(str(BASE / "content/research/*.md"))):
+        if "_index" in path:
+            continue
+        fm, body = parse_fm(read(Path(path)))
+        col_title = esc(fm.get("column_title", ""))
+        body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).strip()
+        inner = md_to_html(body_clean)
+        inner = inner.replace("<ul>", '<ul class="pf-research-list">')
+        cols_html += f"""    <div class="pf-research-col">
+      <h3>{col_title}</h3>
+{inner}
+    </div>\n"""
+
+    return f"""<section class="pf-section pf-wrap reveal" id="research" data-nav>
+  <div class="pf-section-label">04 &mdash; Research &amp; Patents</div>
+  <h2 class="pf-section-title">Research &amp; Patents</h2>
+  <div class="pf-research-grid">
+{cols_html}  </div>
+</section>"""
+
+
+def build_speaking() -> str:
+    fm, body = parse_fm(read(BASE / "content/speaking/_index.md"))
+    title = esc(fm.get("title", "Speaking"))
+    count = esc(fm.get("count", "100+"))
+    count_label = esc(fm.get("count_label", "global security forums and conferences"))
+    note = md_inline(fm.get("note", ""))
+
+    body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).strip()
+    venues = [v.strip() for v in body_clean.split("|") if v.strip()]
+    venues_html = "".join(f'<span class="pf-tag-pill">{esc(v)}</span>' for v in venues)
+
+    return f"""<section class="pf-section pf-wrap reveal" id="speaking" data-nav>
+  <div class="pf-section-label">05 &mdash; Speaking</div>
+  <h2 class="pf-section-title">{title}</h2>
+  <div class="pf-speaking-number">{count}</div>
+  <div class="pf-speaking-label">{count_label}</div>
+  <div class="pf-tag-cloud">
+    {venues_html}
+  </div>
+  <p class="pf-speaking-note">{note}</p>
+</section>"""
+
+
+def build_community() -> str:
+    fm, body = parse_fm(read(BASE / "content/community.md"))
+    title = esc(fm.get("title", "Community & Service"))
+
+    body_clean = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL).strip()
+    cards_html = ""
+    blocks = re.split(r"^###\s+", body_clean, flags=re.MULTILINE)
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        lines = block.split("\n")
+        card_title = lines[0].strip()
+        desc_lines = []
+        tags: list[str] = []
+        for ln in lines[1:]:
+            ln = ln.strip()
+            if not ln:
+                continue
+            if ln.startswith("Tags:"):
+                tags = [t.strip() for t in ln[5:].split("|") if t.strip()]
+            else:
+                desc_lines.append(ln)
+        desc = " ".join(desc_lines)
+        tags_html = "".join(f'<span class="pf-community-tag">{esc(t)}</span>' for t in tags)
+        cards_html += f"""    <div class="pf-community-card">
+      <h3>{md_inline(card_title)}</h3>
+      <p>{md_inline(desc)}</p>
+      <div class="pf-community-tags">{tags_html}</div>
+    </div>\n"""
+
+    return f"""<section class="pf-section pf-wrap reveal" id="community" data-nav>
+  <div class="pf-section-label">06 &mdash; Community &amp; Service</div>
+  <h2 class="pf-section-title">{title}</h2>
+  <div class="pf-community-grid">
+{cards_html}  </div>
+</section>"""
+
+
+def build_education() -> str:
+    fm, body = parse_fm(read(BASE / "content/education.md"))
+    title = esc(fm.get("title", "Education"))
+
+    items_html = ""
+    for line in body.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("<!--"):
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 3:
+            continue
+        # normalise dashes in year range
+        year = esc(parts[0]).replace("–", "&ndash;").replace("-", "&ndash;")
+        degree = esc(parts[1])
+        school = esc(parts[2])
+        detail = (
+            f'\n        <div class="pf-edu-detail">{esc(parts[3])}</div>'
+            if len(parts) > 3
+            else ""
+        )
+        items_html += f"""    <li class="pf-edu-item">
+      <span class="pf-edu-year">{year}</span>
+      <div>
+        <div class="pf-edu-degree">{degree}</div>
+        <div class="pf-edu-school">{school}</div>{detail}
+      </div>
+    </li>\n"""
+
+    return f"""<section class="pf-section pf-wrap reveal" id="education" data-nav>
+  <div class="pf-section-label">07 &mdash; Education</div>
+  <h2 class="pf-section-title">{title}</h2>
+  <ul class="pf-edu-list">
+{items_html}  </ul>
+</section>"""
+
+
+def build_contact() -> str:
+    fm, body = parse_fm(read(BASE / "content/contact.md"))
+    headline = md_inline(fm.get("headline", "Let&rsquo;s build something secure together"))
+    subtext = esc(fm.get("subtext", ""))
+
+    links_html = ""
+    for line in body.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("<!--"):
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 3:
+            continue
+        label = esc(parts[0])
+        display = esc(parts[1])
+        href = parts[2]
+        extra = ' target="_blank" rel="noopener"' if href.startswith("http") else ""
+        links_html += f"""      <li>
+        <a class="pf-contact-link" href="{href}"{extra}>
+          <span class="pf-contact-type">{label}</span>
+          <span class="pf-contact-value">{display}</span>
+          <span class="pf-contact-arrow">&nearr;</span>
+        </a>
+      </li>\n"""
+
+    return f"""<section class="pf-contact pf-wrap reveal" id="contact" data-nav>
+  <div class="pf-contact-grid">
+    <div>
+      <h2 class="pf-contact-headline">{headline}</h2>
+      <p class="pf-contact-sub">{subtext}</p>
+    </div>
+    <ul class="pf-contact-links">
+{links_html}    </ul>
+  </div>
+</section>"""
+
+
+# ---------------------------------------------------------------------------
+# Blog manifest
+# ---------------------------------------------------------------------------
+
+def build_manifest() -> list[dict]:
+    manifest = []
+    for md_path in sorted(glob.glob(str(BASE / "posts/*.md"))):
+        slug = Path(md_path).stem
+        if slug == "upcoming":
+            continue
+        text = read(Path(md_path))
+        fm, _ = parse_fm(text)
+        if not fm:
+            continue
+
+        tags_raw = fm.get("tags", [])
+        if isinstance(tags_raw, str):
+            tags_raw = [
+                t.strip().strip('"').strip("'")
+                for t in tags_raw.strip("[]").split(",")
+            ]
+        tags = [t for t in tags_raw if t]
+
+        manifest.append(
+            {
+                "slug": slug,
+                "title": fm.get("title", slug.replace("-", " ").title()),
+                "date": fm.get("date", "")[:10],
+                "description": fm.get("description", ""),
+                "tags": tags,
+            }
+        )
+
+    manifest.sort(key=lambda x: x["date"], reverse=True)
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Extra CSS (blog/post views, SPA view toggling)
+# ---------------------------------------------------------------------------
+
+EXTRA_CSS = """
+/* ── SPA view management — JS controls via style.display ── */
+#blog-view, #post-view { display: none; }
+
+/* ── Blog listing ── */
+.pf-blog-header { padding: 6rem 0 2rem; }
+.pf-blog-title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(2rem,4vw,3rem); font-weight:500; color:#e8ecf1;
+  margin-bottom:.5rem;
+}
+.pf-blog-back, .pf-post-back {
+  display:inline-flex; align-items:center; gap:.4rem;
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.75rem; color:#64ffda; letter-spacing:.5px;
+  margin-bottom:2rem; transition:opacity .2s; cursor:pointer;
+  text-decoration:none;
+}
+.pf-blog-back:hover, .pf-post-back:hover { opacity:.7; }
+.pf-blog-search-row { display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1.5rem; }
+.pf-blog-search {
+  flex:1; min-width:200px;
+  background:rgba(255,255,255,.04); border:1px solid rgba(100,255,218,.12);
+  border-radius:4px; padding:.55rem 1rem;
+  color:#e8ecf1; font-family:'IBM Plex Sans',sans-serif; font-size:.9rem;
+  outline:none; transition:border-color .2s;
+}
+.pf-blog-search::placeholder { color:#6a7384; }
+.pf-blog-search:focus { border-color:rgba(100,255,218,.35); }
+.pf-blog-filter-row { display:flex; gap:.4rem; flex-wrap:wrap; margin-bottom:2rem; }
+.pf-blog-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.68rem; padding:.25rem .7rem;
+  border:1px solid rgba(100,255,218,.15); border-radius:20px;
+  color:#8892a4; cursor:pointer; transition:all .18s; background:none;
+}
+.pf-blog-tag:hover, .pf-blog-tag.active { border-color:#64ffda; color:#64ffda; }
+.pf-blog-grid {
+  display:grid; grid-template-columns:1fr 1fr; gap:1px;
+  background:rgba(100,255,218,.06);
+  border:1px solid rgba(100,255,218,.06);
+  border-radius:6px; overflow:hidden; margin-bottom:4rem;
+}
+.pf-blog-card {
+  background:#0c1018; padding:1.6rem 1.6rem;
+  transition:background .2s; cursor:pointer;
+  display:flex; flex-direction:column; gap:.5rem;
+}
+.pf-blog-card:hover { background:#111620; }
+.pf-blog-card-date {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.7rem; color:#6a7384;
+}
+.pf-blog-card-title {
+  font-family:'Cormorant Garamond',serif;
+  font-size:1.1rem; font-weight:500; color:#e8ecf1; line-height:1.3;
+}
+.pf-blog-card-desc { font-size:.82rem; color:#8892a4; line-height:1.6; flex:1; }
+.pf-blog-card-tags { display:flex; flex-wrap:wrap; gap:.3rem; margin-top:.3rem; }
+.pf-blog-card-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.64rem; padding:.15rem .45rem; border-radius:3px;
+  background:rgba(100,255,218,.06); color:#6a7384;
+}
+.pf-blog-empty {
+  grid-column:1/-1; padding:3rem;
+  text-align:center; color:#6a7384; font-size:.9rem;
+}
+
+/* ── Post view ── */
+.pf-post-header { padding:6rem 0 2rem; }
+.pf-post-meta { display:flex; gap:1rem; align-items:center; margin-bottom:1.2rem; flex-wrap:wrap; }
+.pf-post-date { font-family:'IBM Plex Mono',monospace; font-size:.75rem; color:#6a7384; }
+.pf-post-tags { display:flex; gap:.35rem; flex-wrap:wrap; }
+.pf-post-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.66rem; padding:.15rem .5rem; border-radius:3px;
+  background:rgba(100,255,218,.06); color:#8892a4;
+}
+.pf-post-title {
+  font-family:'Cormorant Garamond',serif;
+  font-size:clamp(1.8rem,3.5vw,2.8rem);
+  font-weight:500; color:#e8ecf1; line-height:1.2; margin-bottom:2.5rem;
+}
+.pf-post-content {
+  max-width:720px;
+  font-size:.95rem; line-height:1.78; color:#9aa0b0; margin-bottom:4rem;
+}
+.pf-post-content h1,.pf-post-content h2,.pf-post-content h3 {
+  font-family:'Cormorant Garamond',serif; color:#e8ecf1;
+  margin:2rem 0 .8rem; font-weight:500;
+}
+.pf-post-content h2 { font-size:1.5rem; }
+.pf-post-content h3 { font-size:1.2rem; }
+.pf-post-content p { margin-bottom:1.1rem; }
+.pf-post-content ul,.pf-post-content ol { margin:0 0 1.1rem 1.4rem; }
+.pf-post-content li { margin-bottom:.4rem; }
+.pf-post-content strong { color:#cdd3df; }
+.pf-post-content code {
+  font-family:'IBM Plex Mono',monospace; font-size:.85em;
+  background:rgba(100,255,218,.06); padding:.15rem .4rem;
+  border-radius:3px; color:#64ffda;
+}
+.pf-post-content pre {
+  background:rgba(0,0,0,.3); border:1px solid rgba(100,255,218,.08);
+  border-radius:6px; padding:1.2rem 1.4rem; overflow-x:auto; margin-bottom:1.2rem;
+}
+.pf-post-content pre code { background:none; padding:0; border-radius:0; color:#9aa0b0; }
+.pf-post-content blockquote {
+  border-left:2px solid #64ffda; padding-left:1rem;
+  color:#6a7384; font-style:italic; margin:1.2rem 0;
+}
+.pf-post-content a { color:#64ffda; }
+.pf-post-content hr { border:none; border-top:1px solid rgba(100,255,218,.1); margin:2rem 0; }
+.pf-post-loading {
+  text-align:center; padding:3rem; color:#6a7384;
+  font-family:'IBM Plex Mono',monospace; font-size:.85rem;
+}
+
+@media (max-width:768px) {
+  .pf-blog-grid { grid-template-columns:1fr; }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Inline JS
+# ---------------------------------------------------------------------------
+
+def build_js(manifest: list[dict]) -> str:
+    manifest_json = json.dumps(manifest, ensure_ascii=False)
+    return f"""
+// ── Blog manifest (embedded at build time) ──────────────────────────────────
+const BLOG = {manifest_json};
+
+// ── Utility ─────────────────────────────────────────────────────────────────
+function escHtml(s) {{
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}}
+
+// ── Nav toggle ───────────────────────────────────────────────────────────────
+const navToggle = document.querySelector('.pf-nav-toggle');
+const navLinks  = document.querySelector('.pf-nav-links');
+navToggle?.addEventListener('click', () => navLinks.classList.toggle('open'));
+document.querySelectorAll('.pf-nav-links a').forEach(a =>
+  a.addEventListener('click', () => navLinks.classList.remove('open')));
+
+// ── Scroll-reveal ────────────────────────────────────────────────────────────
+const revealObs = new IntersectionObserver(
+  entries => entries.forEach(e => {{ if (e.isIntersecting) e.target.classList.add('visible'); }}),
+  {{ threshold: .08 }}
+);
+document.querySelectorAll('.reveal').forEach(el => revealObs.observe(el));
+
+// ── Counter animation ────────────────────────────────────────────────────────
+function animateCounter(el) {{
+  const target = +el.dataset.count;
+  const dur = 1400;
+  const start = performance.now();
+  const step = now => {{
+    const p = Math.min((now - start) / dur, 1);
+    el.textContent = Math.floor(p * p * (3 - 2 * p) * target);
+    if (p < 1) requestAnimationFrame(step); else el.textContent = target;
+  }};
+  requestAnimationFrame(step);
+}}
+const ctrObs = new IntersectionObserver(entries => {{
+  entries.forEach(e => {{
+    if (e.isIntersecting) {{
+      e.target.querySelectorAll('[data-count]').forEach(animateCounter);
+      ctrObs.unobserve(e.target);
+    }}
+  }});
+}}, {{ threshold: .3 }});
+const metricsEl = document.querySelector('.pf-metrics');
+if (metricsEl) ctrObs.observe(metricsEl);
+
+// ── Active nav highlight ─────────────────────────────────────────────────────
+const navAnchors = document.querySelectorAll('.pf-nav-links a');
+const activeObs  = new IntersectionObserver(entries => {{
+  entries.forEach(e => {{
+    if (!e.isIntersecting) return;
+    navAnchors.forEach(a => a.classList.remove('active'));
+    const a = document.querySelector(`.pf-nav-links a[href="#${{e.target.id}}"]`);
+    if (a) a.classList.add('active');
+  }});
+}}, {{ rootMargin: '-40% 0px -55% 0px' }});
+document.querySelectorAll('[data-nav]').forEach(s => activeObs.observe(s));
+
+// ── SPA router ───────────────────────────────────────────────────────────────
+const VIEW_HOME = document.getElementById('home-view');
+const VIEW_BLOG = document.getElementById('blog-view');
+const VIEW_POST = document.getElementById('post-view');
+
+function showView(name) {{
+  VIEW_HOME.style.display = name === 'home' ? '' : 'none';
+  VIEW_BLOG.style.display = name === 'blog' ? '' : 'none';
+  VIEW_POST.style.display = name === 'post' ? '' : 'none';
+  window.scrollTo(0, 0);
+}}
+
+function route() {{
+  const h = location.hash;
+  if (h.startsWith('#blog/')) {{
+    showView('post');
+    loadPost(h.slice(6));
+  }} else if (h === '#blog') {{
+    showView('blog');
+    renderBlog();
+  }} else {{
+    showView('home');
+    if (h && h !== '#') {{
+      setTimeout(() => {{
+        const el = document.querySelector(h);
+        if (el) el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+      }}, 50);
+    }}
+  }}
+}}
+
+window.addEventListener('hashchange', route);
+document.addEventListener('DOMContentLoaded', route);
+
+// Intercept "View all blog posts" without changing to a separate page
+document.getElementById('view-all-blog')?.addEventListener('click', e => {{
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+}});
+
+// ── Blog listing ─────────────────────────────────────────────────────────────
+let activeTag = null;
+let searchQ   = '';
+
+function renderBlog() {{
+  const tagRow   = document.getElementById('blog-tag-row');
+  const cards    = document.getElementById('blog-cards');
+  if (!cards) return;
+
+  if (tagRow && !tagRow.dataset.built) {{
+    tagRow.dataset.built = '1';
+    const tags = [...new Set(BLOG.flatMap(p => p.tags || []))].sort();
+    tags.forEach(tag => {{
+      const btn = document.createElement('button');
+      btn.className = 'pf-blog-tag';
+      btn.textContent = tag;
+      btn.addEventListener('click', () => {{
+        activeTag = activeTag === tag ? null : tag;
+        tagRow.querySelectorAll('.pf-blog-tag').forEach(b => b.classList.remove('active'));
+        if (activeTag) btn.classList.add('active');
+        renderCards();
+      }});
+      tagRow.appendChild(btn);
+    }});
+  }}
+  renderCards();
+}}
+
+function renderCards() {{
+  const cards = document.getElementById('blog-cards');
+  if (!cards) return;
+
+  let posts = BLOG;
+  if (activeTag) posts = posts.filter(p => (p.tags || []).includes(activeTag));
+  if (searchQ)   posts = posts.filter(p =>
+    p.title.toLowerCase().includes(searchQ) ||
+    (p.description || '').toLowerCase().includes(searchQ)
+  );
+
+  if (!posts.length) {{
+    cards.innerHTML = '<div class="pf-blog-empty">No posts match your search.</div>';
+    return;
+  }}
+
+  cards.innerHTML = posts.map(p => {{
+    const d = p.date ? new Date(p.date + 'T00:00:00').toLocaleDateString('en-US', {{
+      year: 'numeric', month: 'short', day: 'numeric'
+    }}) : '';
+    const tagPills = (p.tags || []).slice(0, 4)
+      .map(t => `<span class="pf-blog-card-tag">${{escHtml(t)}}</span>`).join('');
+    return `<div class="pf-blog-card" onclick="location.hash='#blog/${{encodeURIComponent(p.slug)}}'">
+      <div class="pf-blog-card-date">${{d}}</div>
+      <div class="pf-blog-card-title">${{escHtml(p.title)}}</div>
+      <div class="pf-blog-card-desc">${{escHtml(p.description || '')}}</div>
+      <div class="pf-blog-card-tags">${{tagPills}}</div>
+    </div>`;
+  }}).join('');
+}}
+
+document.getElementById('blog-search')?.addEventListener('input', e => {{
+  searchQ = e.target.value.trim().toLowerCase();
+  renderCards();
+}});
+
+document.getElementById('blog-back')?.addEventListener('click', e => {{
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+}});
+
+// ── Post viewer ───────────────────────────────────────────────────────────────
+async function loadPost(slug) {{
+  const slug_dec = decodeURIComponent(slug);
+  const titleEl   = document.getElementById('post-title');
+  const dateEl    = document.getElementById('post-date');
+  const tagsEl    = document.getElementById('post-tags');
+  const contentEl = document.getElementById('post-content');
+
+  if (titleEl)   titleEl.textContent = '';
+  if (contentEl) contentEl.innerHTML = '<div class="pf-post-loading">Loading&hellip;</div>';
+
+  const meta = BLOG.find(p => p.slug === slug_dec);
+  if (meta) {{
+    if (titleEl) titleEl.textContent = meta.title;
+    if (dateEl)  dateEl.textContent = meta.date
+      ? new Date(meta.date + 'T00:00:00').toLocaleDateString('en-US', {{
+          year: 'numeric', month: 'long', day: 'numeric'
+        }})
+      : '';
+    if (tagsEl) tagsEl.innerHTML = (meta.tags || [])
+      .map(t => `<span class="pf-post-tag">${{escHtml(t)}}</span>`).join('');
+  }}
+
+  try {{
+    const res = await fetch(`posts/${{slug_dec}}.md`);
+    if (!res.ok) throw new Error('fetch failed');
+    let md = await res.text();
+    md = md.replace(/^---[\\s\\S]*?---\\n?/, '');
+    contentEl.innerHTML = typeof marked !== 'undefined'
+      ? marked.parse(md)
+      : `<pre>${{escHtml(md)}}</pre>`;
+  }} catch (_) {{
+    contentEl.innerHTML = '<p style="color:#6a7384">Could not load this post.</p>';
+  }}
+}}
+
+document.getElementById('post-back')?.addEventListener('click', e => {{
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+}});
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main assembler
+# ---------------------------------------------------------------------------
+
+def build() -> None:
+    site_fm, _ = parse_fm(read(BASE / "content/site.md"))
+
+    css = read(BASE / "css/portfolio.css")
+    manifest = build_manifest()
+
+    # Write updated posts/index.json
+    (BASE / "posts/index.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    hero_html      = build_hero()
+    work_html      = build_work()
+    recog_html     = build_recognition()
+    writing_html   = build_writing()
+    research_html  = build_research()
+    speaking_html  = build_speaking()
+    community_html = build_community()
+    education_html = build_education()
+    contact_html   = build_contact()
+    js             = build_js(manifest)
+
+    # Site metadata
+    title    = esc(site_fm.get("title", "Dr. Soumya Maity"))
+    desc     = esc(site_fm.get("description", ""))
+    og_title = esc(site_fm.get("og_title", ""))
+    og_desc  = esc(site_fm.get("og_description", ""))
+    og_image = esc(site_fm.get("og_image", "assets/images/author/maity.png"))
+    og_url   = esc(site_fm.get("og_url", "https://smaity.co.in"))
+    domain   = esc(site_fm.get("domain", "smaity.co.in"))
+    favicon  = esc(site_fm.get("favicon", "assets/images/site/favicon.png"))
+    footer_t = esc(site_fm.get("footer", "© 2025 Dr. Soumya Maity · Bengaluru, India"))
+    footer_t = footer_t.replace("&amp;middot;", "&middot;")
+
+    footer_html = f"""<footer class="pf-footer pf-wrap">
+  <span>{footer_t}</span>
+  <span class="pf-footer-domain">{domain}</span>
+</footer>"""
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+  <meta name="description" content="{desc}">
+  <meta property="og:title" content="{og_title}">
+  <meta property="og:type" content="website">
+  <meta property="og:description" content="{og_desc}">
+  <meta property="og:image" content="{og_image}">
+  <meta property="og:url" content="{og_url}">
+  <link rel="icon" href="{favicon}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Sans:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+{css}
+{EXTRA_CSS}
+  </style>
+</head>
+<body>
+
+<nav class="pf-nav">
+  <a href="#" class="pf-nav-brand">Dr. Soumya <span class="accent">Maity</span></a>
+  <button class="pf-nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+  <ul class="pf-nav-links">
+    <li><a href="#work">Work</a></li>
+    <li><a href="#writing">Writing</a></li>
+    <li><a href="#research">Research</a></li>
+    <li><a href="#speaking">Speaking</a></li>
+    <li><a href="#blog">Blog</a></li>
+    <li><a href="#contact" class="nav-contact">Contact</a></li>
+  </ul>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════
+     HOME VIEW  (default — all sections scroll normally)
+═══════════════════════════════════════════════════════════ -->
+<div id="home-view" class="spa-view">
+
+{hero_html}
+
+{work_html}
+
+{recog_html}
+
+{writing_html}
+
+{research_html}
+
+{speaking_html}
+
+{community_html}
+
+{education_html}
+
+{contact_html}
+
+{footer_html}
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
+     BLOG VIEW  (#blog)
+═══════════════════════════════════════════════════════════ -->
+<div id="blog-view" class="spa-view">
+  <div class="pf-wrap">
+    <div class="pf-blog-header">
+      <a href="#" id="blog-back" class="pf-blog-back">&larr; Back to home</a>
+      <h1 class="pf-blog-title">All Writing</h1>
+      <div class="pf-blog-search-row">
+        <input id="blog-search" class="pf-blog-search" type="search"
+               placeholder="Search {len(manifest)} posts&hellip;" autocomplete="off">
+      </div>
+      <div id="blog-tag-row" class="pf-blog-filter-row"></div>
+    </div>
+    <div id="blog-cards" class="pf-blog-grid"></div>
+  </div>
+  {footer_html}
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
+     POST VIEW  (#blog/<slug>)
+═══════════════════════════════════════════════════════════ -->
+<div id="post-view" class="spa-view">
+  <div class="pf-wrap">
+    <div class="pf-post-header">
+      <a href="#" id="post-back" class="pf-post-back">&larr; All posts</a>
+      <div class="pf-post-meta">
+        <span id="post-date" class="pf-post-date"></span>
+        <div id="post-tags" class="pf-post-tags"></div>
+      </div>
+      <h1 id="post-title" class="pf-post-title"></h1>
+    </div>
+    <div id="post-content" class="pf-post-content"></div>
+  </div>
+  {footer_html}
+</div>
+
+<script>
+{js}
+</script>
+</body>
+</html>"""
+
+    out = BASE / "index.html"
+    out.write_text(html, encoding="utf-8")
+    print(f"✓  Built {out}  ({len(html):,} bytes, {len(manifest)} blog posts)")
+
+
+if __name__ == "__main__":
+    build()

--- a/content/community.md
+++ b/content/community.md
@@ -1,0 +1,26 @@
+---
+label: "06 — Community & Service"
+title: Community & Service
+---
+
+<!-- Format per card:
+### Card Title
+Description paragraph.
+Tags: Tag One | Tag Two | Tag Three
+-->
+
+### Cyber Vidhi Sangam
+Founding trustee of a non-profit techno-legal forum making cyber law accessible to ordinary citizens and providing direct support to cybercrime victims. Bridging the gap between legal systems and technology for people who need it most.
+Tags: Founding trustee | Cyber law | Non-profit
+
+### Professor of Practice
+Teaching cryptography, security engineering, DevSecOps, and the techno-legal dimensions of AI and data protection law at REVA University, Bengaluru. Designing and delivering courses for executive M.Tech programmes.
+Tags: REVA University | Cryptography | DevSecOps | Cyber law
+
+### Industry Memberships
+Active member and working group participant across the global security community — contributing to standards, frameworks, and the next generation of security practitioners.
+Tags: OWASP | IEEE | SANS | Safecode | DSCI | BSIDES
+
+### Working Groups
+Contributing member of standards-setting bodies shaping how the industry measures, communicates, and responds to security risk in the post-quantum and AI era.
+Tags: CVSS WG | PQC WG | Pan-Dell Patent Review

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,10 @@
+---
+headline: Let's build something secure together
+subtext: Open to conversations about AI security leadership, advisory roles, board-level security consulting, and speaking engagements. Always happy to connect with fellow researchers and practitioners.
+---
+
+<!-- Format: Label | Display Text | href -->
+Email | soumyamaity@gmail.com | mailto:soumyamaity@gmail.com
+LinkedIn | linkedin.com/in/soumyam | https://www.linkedin.com/in/soumyam
+GitHub | github.com/soumyamaity | https://www.github.com/soumyamaity
+Resume | Download full CV (PDF) | files/SMAITY_short_CV.pdf

--- a/content/education.md
+++ b/content/education.md
@@ -1,0 +1,9 @@
+---
+label: "07 — Education"
+title: Education
+---
+
+<!-- Format: year range | Degree | Institution | (optional) Detail note -->
+2009–2014 | PhD, Information Security | Indian Institute of Technology Kharagpur | Dissertation: Access Control Models for Mobile Ad Hoc Networks
+2024–2026 | PGD, Cyber Law & Cyber Forensics | National Law School of India University (NLSIU), Bengaluru
+2004–2008 | B.Tech, Computer Science & Engineering | Institute of Engineering & Management, Kolkata · CGPA 8.6/10

--- a/content/hero.md
+++ b/content/hero.md
@@ -1,0 +1,20 @@
+---
+eyebrow: BusinessWorld Security 40under40 · 2024
+headline: Building the security foundations that *AI-era* products run on
+m1_count: 16
+m1_suffix: +
+m1_label: Years in product security
+m2_count: 10
+m2_suffix: k+
+m2_label: Products secured at Dell
+m3_count: 20
+m3_suffix: +
+m3_label: IEEE / ACM publications
+m4_count: 100
+m4_suffix: +
+m4_label: Global speaking engagements
+cv_href: files/SMAITY_short_CV.pdf
+---
+Distinguished product security architect at Dell Technologies. Leading AI security governance, post-quantum cryptography readiness, and open-source trust at enterprise scale — across 10,000+ products and 50,000+ developers.
+
+PhD, IIT Kharagpur · 4 US Patents · Professor of Practice, REVA University.

--- a/content/recognition.md
+++ b/content/recognition.md
@@ -1,0 +1,11 @@
+---
+label: "02 — Recognition"
+title: Recognition
+---
+
+<!-- Format: year | Award Name | Organisation | (optional) LATEST -->
+2024 | BusinessWorld Security 40under40 | BusinessWorld India | LATEST
+2022 | Distinguished Member of Technical Staff | Dell Technologies
+2021 | Game Changer Award — 4× recipient | Dell Technologies
+2016 | IEM Young Alumnus Award | Institute of Engineering & Management
+2014 | Best Idea for Innovation | Samsung Research Institute

--- a/content/research/_index.md
+++ b/content/research/_index.md
@@ -1,0 +1,4 @@
+---
+label: "04 — Research & Patents"
+title: Research & Patents
+---

--- a/content/research/patents.md
+++ b/content/research/patents.md
@@ -1,0 +1,9 @@
+---
+column_title: US Patents
+---
+
+<!-- Add one bullet per patent. Use plain text; markdown bold **…** is supported. -->
+- Method and system for establishing trust between nodes in a network based on recommendations
+- System for query-based interactive risk model analysis for secure software development
+- Patent in product security (details on request)
+- Patent in product security (details on request)

--- a/content/research/publications.md
+++ b/content/research/publications.md
@@ -1,0 +1,11 @@
+---
+column_title: Selected Publications
+---
+
+<!-- Add one bullet per publication. A trailing italic note (using *…*) renders as a muted footnote. -->
+- Threat Modeling of Cloud-Based Homomorphic Encryption — IJCIS 2020
+- PoliCon: Policy Conciliation for Heterogeneous MANETs — Wiley SCN 2015
+- FINSAT: Formal Network Security Configuration Analysis — IET Networks 2014
+- Conflict Resolution in Co-allied MANET — ICDCN / Springer 2015
+
+*+ 16 further IEEE/ACM papers & 1 book chapter*

--- a/content/site.md
+++ b/content/site.md
@@ -1,0 +1,12 @@
+---
+title: Dr. Soumya Maity | Security Architect & Researcher
+description: Distinguished product security architect at Dell Technologies. AI security governance, post-quantum cryptography, open-source trust at enterprise scale.
+og_title: Dr. Soumya Maity — Security Architect
+og_description: Building the security foundations that AI-era products run on.
+og_image: assets/images/author/maity.png
+og_url: https://smaity.co.in
+domain: smaity.co.in
+nav_brand: Dr. Soumya Maity
+favicon: assets/images/site/favicon.png
+footer: © 2025 Dr. Soumya Maity · Bengaluru, India
+---

--- a/content/speaking/_index.md
+++ b/content/speaking/_index.md
@@ -1,0 +1,10 @@
+---
+label: "05 — Speaking"
+title: Speaking
+count: 100+
+count_label: national and global security forums, conferences, and universities
+note: Available for keynotes, panels, and advisory conversations on AI security, post-quantum cryptography, and the techno-legal dimensions of cyber governance.
+---
+
+<!-- Pipe-separated list of venues shown as tag pills -->
+OWASP | DSCI | BSIDES | IEEE Forums | SANS Community | Nullcon | ClubHack | IIT Guest Lectures | Industry Panels | University Forums

--- a/content/work/01-ai-threat-library.md
+++ b/content/work/01-ai-threat-library.md
@@ -1,0 +1,6 @@
+---
+label: AI Security
+title: Enterprise AI Threat Library
+featured: true
+---
+Building a comprehensive catalogue of AI abuse cases and SDL-phase mitigations — the foundational framework for securing generative AI products at enterprise scale. Includes adversarial prompt threats, model inversion, data poisoning, and supply-chain attacks on model weights.

--- a/content/work/02-pqc-readiness.md
+++ b/content/work/02-pqc-readiness.md
@@ -1,0 +1,6 @@
+---
+label: Post-Quantum Cryptography
+title: PQC Readiness for Dell Products
+featured: true
+---
+Leading the cryptographic migration study for CRYSTALS-Kyber (FIPS-203) and CRYSTALS-Dilithium (FIPS-204/205) across the Dell product portfolio — ahead of the NIST mandate. Includes cryptographic asset inventory, hybrid transition planning, and CBOM creation.

--- a/content/work/03-oss-trust-model.md
+++ b/content/work/03-oss-trust-model.md
@@ -1,0 +1,6 @@
+---
+label: Supply Chain Security
+title: Open-Source Trustworthiness Model
+featured: false
+---
+A dynamic risk model for OSS components that goes beyond point-in-time CVE scanning: fix velocity, issue-open ratios, CI/CD security gate quality, and update cadence as first-class trust signals. Operationalized as automated quality gates across Dell's product pipelines.

--- a/content/work/04-sbom-cbom.md
+++ b/content/work/04-sbom-cbom.md
@@ -1,0 +1,6 @@
+---
+label: Governance & Compliance
+title: SBOM + Crypto Bill of Materials
+featured: false
+---
+Creating SBOM and CBOM infrastructure to classify all software and cryptographic dependencies into risk zones (Red / Yellow / Green), enabling board-level visibility into supply-chain and cryptographic exposure across the enterprise.

--- a/content/work/_index.md
+++ b/content/work/_index.md
@@ -1,0 +1,4 @@
+---
+label: "01 — Current focus"
+title: What I am building now
+---

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -6,6 +6,8 @@ posts_dir = os.path.join(os.path.dirname(__file__), "posts")
 manifest = []
 
 for md_path in sorted(glob.glob(os.path.join(posts_dir, "*.md"))):
+    if os.path.basename(md_path) == "upcoming.md":
+        continue
     slug = os.path.splitext(os.path.basename(md_path))[0]
     with open(md_path, "r", encoding="utf-8") as f:
         content = f.read()
@@ -46,11 +48,9 @@ for md_path in sorted(glob.glob(os.path.join(posts_dir, "*.md"))):
                     in_tags = False
             continue
         if in_tags:
-            if stripped.startswith("- "):
-                tags.append(stripped[2:].strip().strip('"').strip("'"))
-            elif stripped.startswith("-"):
-                tags.append(stripped[1:].strip().strip('"').strip("'"))
-            else:
+            if re.match(r"^\s*-\s+", stripped):
+                tags.append(re.sub(r"^\s*-\s+", "", stripped).strip().strip('"').strip("'"))
+            elif stripped and not stripped.startswith("#"):
                 in_tags = False
 
     # Normalize date to YYYY-MM-DD

--- a/index.html
+++ b/index.html
@@ -14,13 +14,656 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Sans:wght@300;400;500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/portfolio.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+/* ===== Portfolio — Dark Editorial Theme ===== */
+
+/* --- Reset & Base --- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 72px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  background: #080c12;
+  color: #b0b8c8;
+  font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.72;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* dot-grid texture */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(100,255,218,.045) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+::selection { background: #64ffda; color: #080c12; }
+
+a { color: #64ffda; text-decoration: none; transition: color .2s, opacity .2s; }
+a:hover { opacity: .82; }
+
+img { max-width: 100%; display: block; }
+
+/* Utility */
+.accent   { color: #64ffda; }
+.muted    { color: #6a7384; }
+.mono     { font-family: 'IBM Plex Mono', monospace; }
+.serif    { font-family: 'Cormorant Garamond', Georgia, serif; }
+
+/* ------------------------------------------------------------------ */
+/*  FADE-UP  reveal animation                                         */
+/* ------------------------------------------------------------------ */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity .7s cubic-bezier(.16,1,.3,1), transform .7s cubic-bezier(.16,1,.3,1);
+}
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* hero stagger */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.hero-anim {
+  opacity: 0;
+  animation: fadeUp .8s cubic-bezier(.16,1,.3,1) forwards;
+}
+.hero-anim-1 { animation-delay: .1s; }
+.hero-anim-2 { animation-delay: .25s; }
+.hero-anim-3 { animation-delay: .4s; }
+.hero-anim-4 { animation-delay: .55s; }
+.hero-anim-5 { animation-delay: .7s; }
+
+/* ------------------------------------------------------------------ */
+/*  NAVIGATION                                                        */
+/* ------------------------------------------------------------------ */
+.pf-nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 1000;
+  height: 64px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 clamp(1.2rem, 4vw, 3rem);
+  background: rgba(8,12,18,.72);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(100,255,218,.07);
+}
+
+.pf-nav-brand {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.2rem; font-weight: 500; color: #e8ecf1;
+  letter-spacing: .3px;
+}
+.pf-nav-brand .accent { color: #64ffda; }
+
+.pf-nav-links { display: flex; gap: 1.8rem; list-style: none; align-items: center; }
+.pf-nav-links a {
+  font-size: .82rem; font-weight: 500; letter-spacing: .6px;
+  text-transform: uppercase; color: #6a7384; transition: color .2s;
+}
+.pf-nav-links a:hover,
+.pf-nav-links a.active { color: #e8ecf1; opacity: 1; }
+
+.pf-nav-links .nav-contact {
+  border: 1px solid rgba(100,255,218,.35);
+  border-radius: 4px;
+  padding: .35rem .9rem;
+  color: #64ffda;
+  font-size: .78rem;
+}
+.pf-nav-links .nav-contact:hover { background: rgba(100,255,218,.08); opacity: 1; }
+
+.pf-nav-toggle {
+  display: none; background: none; border: 1px solid rgba(100,255,218,.2);
+  color: #64ffda; font-size: 1.2rem; padding: .25rem .5rem; cursor: pointer;
+  border-radius: 4px;
+}
+
+/* ------------------------------------------------------------------ */
+/*  LAYOUT                                                            */
+/* ------------------------------------------------------------------ */
+.pf-wrap {
+  position: relative; z-index: 1;
+  max-width: 1100px; margin: 0 auto;
+  padding: 0 clamp(1.2rem, 4vw, 3rem);
+}
+
+.pf-section {
+  padding: 6rem 0 2rem;
+}
+
+.pf-section-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .72rem; font-weight: 500; letter-spacing: 2px;
+  text-transform: uppercase; color: #64ffda;
+  margin-bottom: .6rem;
+}
+
+.pf-section-title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+  font-weight: 500; color: #e8ecf1;
+  line-height: 1.25; margin-bottom: 2.4rem;
+}
+
+/* ------------------------------------------------------------------ */
+/*  HERO                                                              */
+/* ------------------------------------------------------------------ */
+.pf-hero {
+  min-height: 100vh; display: flex; flex-direction: column;
+  justify-content: center; padding-top: 64px;
+}
+
+.pf-hero-eyebrow {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .78rem; color: #64ffda; font-weight: 500;
+  display: flex; align-items: center; gap: .8rem;
+  margin-bottom: 1.4rem;
+}
+.pf-hero-eyebrow::before {
+  content: ''; width: 32px; height: 1px; background: #64ffda;
+}
+
+.pf-hero-headline {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(2.4rem, 5.6vw, 4.25rem);
+  font-weight: 500; color: #e8ecf1;
+  line-height: 1.12; max-width: 820px;
+  margin-bottom: 1.6rem;
+}
+.pf-hero-headline em {
+  font-style: italic; color: #64ffda;
+}
+
+.pf-hero-sub {
+  max-width: 580px; font-size: .94rem; line-height: 1.72;
+  color: #8892a4; margin-bottom: 2.2rem;
+}
+
+.pf-hero-buttons { display: flex; gap: .8rem; flex-wrap: wrap; }
+
+.pf-btn {
+  display: inline-flex; align-items: center; gap: .4rem;
+  padding: .6rem 1.4rem; border-radius: 4px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: .84rem; font-weight: 500;
+  cursor: pointer; transition: all .2s; text-decoration: none;
+  border: 1px solid transparent;
+}
+.pf-btn-fill {
+  background: #64ffda; color: #080c12; border-color: #64ffda;
+}
+.pf-btn-fill:hover { background: #52e8c5; border-color: #52e8c5; opacity: 1; }
+.pf-btn-ghost {
+  background: transparent; color: #b0b8c8;
+  border-color: rgba(176,184,200,.25);
+}
+.pf-btn-ghost:hover { border-color: #64ffda; color: #64ffda; opacity: 1; }
+
+/* ------------------------------------------------------------------ */
+/*  METRICS ROW                                                       */
+/* ------------------------------------------------------------------ */
+.pf-metrics {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border: 1px solid rgba(100,255,218,.1);
+  border-radius: 6px;
+  margin-top: 3.5rem;
+}
+.pf-metric {
+  padding: 1.8rem 1.4rem;
+  text-align: center;
+}
+.pf-metric + .pf-metric {
+  border-left: 1px solid rgba(100,255,218,.1);
+}
+.pf-metric-value {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 2.75rem; font-weight: 500; color: #e8ecf1;
+  line-height: 1;
+}
+.pf-metric-value .counter-suffix { font-size: 2rem; }
+.pf-metric-label {
+  font-size: .78rem; color: #6a7384; margin-top: .4rem;
+}
+
+/* ------------------------------------------------------------------ */
+/*  WORK CARDS  (Section 01)                                          */
+/* ------------------------------------------------------------------ */
+.pf-work-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 1px; background: rgba(100,255,218,.08);
+  border: 1px solid rgba(100,255,218,.08);
+  border-radius: 6px; overflow: hidden;
+}
+.pf-work-card {
+  background: #0c1018; padding: 2rem 1.8rem;
+}
+.pf-work-card.featured { border-left: 2px solid #64ffda; }
+.pf-work-card-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .7rem; font-weight: 500; letter-spacing: 1.5px;
+  text-transform: uppercase; color: #64ffda; margin-bottom: .6rem;
+}
+.pf-work-card h3 {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.25rem; font-weight: 500; color: #e8ecf1;
+  margin-bottom: .6rem;
+}
+.pf-work-card p {
+  font-size: .86rem; color: #8892a4; line-height: 1.68;
+}
+
+/* ------------------------------------------------------------------ */
+/*  RECOGNITION TABLE  (Section 02)                                   */
+/* ------------------------------------------------------------------ */
+.pf-recog-list { list-style: none; }
+.pf-recog-item {
+  display: grid; grid-template-columns: 80px 1fr 220px;
+  gap: 1rem; align-items: baseline;
+  padding: 1rem 0;
+  border-bottom: 1px solid rgba(100,255,218,.06);
+  font-size: .9rem;
+}
+.pf-recog-item:last-child { border-bottom: none; }
+.pf-recog-year {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .82rem; color: #64ffda;
+}
+.pf-recog-name { color: #e8ecf1; }
+.pf-recog-org  { color: #6a7384; text-align: right; font-size: .84rem; }
+.pf-badge-latest {
+  display: inline-block; font-family: 'IBM Plex Mono', monospace;
+  font-size: .65rem; font-weight: 500; letter-spacing: .5px;
+  padding: .15rem .5rem; border-radius: 3px;
+  background: rgba(100,255,218,.1); color: #64ffda;
+  margin-left: .5rem; vertical-align: middle;
+}
+
+/* ------------------------------------------------------------------ */
+/*  WRITING  (Section 03)                                             */
+/* ------------------------------------------------------------------ */
+.pf-writing-list { list-style: none; }
+.pf-writing-item {
+  display: grid; grid-template-columns: 48px 1fr auto;
+  gap: 1rem; align-items: start;
+  padding: 1.8rem 0;
+  border-bottom: 1px solid rgba(100,255,218,.06);
+  transition: background .2s;
+}
+.pf-writing-item:last-child { border-bottom: none; }
+.pf-writing-num {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 1.1rem; color: rgba(100,255,218,.35); font-weight: 500;
+}
+.pf-writing-title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.2rem; font-weight: 500; color: #e8ecf1;
+  margin-bottom: .4rem; line-height: 1.3;
+}
+.pf-writing-desc {
+  font-size: .84rem; color: #6a7384; line-height: 1.6;
+  margin-bottom: .6rem;
+}
+.pf-writing-pills { display: flex; flex-wrap: wrap; gap: .35rem; }
+.pf-pill {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .68rem; font-weight: 500;
+  padding: .2rem .6rem; border-radius: 3px;
+  background: rgba(100,255,218,.06);
+  color: #8892a4;
+}
+.pf-pill-soon { color: #64ffda; background: rgba(100,255,218,.1); }
+.pf-writing-arrow {
+  font-size: 1.1rem; color: #6a7384;
+  transition: transform .2s, color .2s;
+  padding-top: .2rem;
+}
+.pf-writing-item:hover .pf-writing-arrow {
+  color: #64ffda; transform: translate(3px, -3px);
+}
+
+/* ------------------------------------------------------------------ */
+/*  RESEARCH & PATENTS  (Section 04)                                  */
+/* ------------------------------------------------------------------ */
+.pf-research-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 3rem;
+}
+.pf-research-col h3 {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.15rem; font-weight: 500; color: #e8ecf1;
+  margin-bottom: 1.2rem;
+  padding-bottom: .6rem;
+  border-bottom: 1px solid rgba(100,255,218,.1);
+}
+.pf-research-list { list-style: none; }
+.pf-research-list li {
+  font-size: .86rem; color: #8892a4; line-height: 1.6;
+  padding: .6rem 0; padding-left: 1rem;
+  position: relative;
+  border-bottom: 1px solid rgba(255,255,255,.03);
+}
+.pf-research-list li::before {
+  content: ''; position: absolute; left: 0; top: 1rem;
+  width: 4px; height: 4px; border-radius: 50%;
+  background: rgba(100,255,218,.35);
+}
+.pf-research-list li:last-child { border-bottom: none; }
+.pf-research-more {
+  font-size: .84rem; color: #6a7384; font-style: italic;
+  padding-left: 1rem; margin-top: .3rem;
+}
+.pf-research-more a { color: #64ffda; }
+
+/* ------------------------------------------------------------------ */
+/*  SPEAKING  (Section 05)                                            */
+/* ------------------------------------------------------------------ */
+.pf-speaking-number {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 4.5rem; font-weight: 400; color: rgba(232,236,241,.08);
+  line-height: 1; margin-bottom: .4rem;
+}
+.pf-speaking-label {
+  font-size: .92rem; color: #8892a4; margin-bottom: 2rem;
+  max-width: 500px;
+}
+.pf-tag-cloud { display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 1.6rem; }
+.pf-tag-pill {
+  font-size: .78rem; padding: .35rem .8rem;
+  border: 1px solid rgba(100,255,218,.15); border-radius: 20px;
+  color: #8892a4; transition: all .2s;
+}
+.pf-tag-pill:hover { border-color: #64ffda; color: #64ffda; }
+.pf-speaking-note {
+  font-size: .86rem; color: #6a7384; font-style: italic;
+  max-width: 640px; line-height: 1.65;
+}
+
+/* ------------------------------------------------------------------ */
+/*  COMMUNITY  (Section 06)                                           */
+/* ------------------------------------------------------------------ */
+.pf-community-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 1px; background: rgba(100,255,218,.06);
+  border: 1px solid rgba(100,255,218,.06);
+  border-radius: 6px; overflow: hidden;
+}
+.pf-community-card {
+  background: #0c1018; padding: 1.8rem 1.6rem;
+}
+.pf-community-card h3 {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.1rem; font-weight: 500; color: #e8ecf1;
+  margin-bottom: .5rem;
+}
+.pf-community-card p {
+  font-size: .84rem; color: #8892a4; line-height: 1.65;
+  margin-bottom: .8rem;
+}
+.pf-community-tags { display: flex; flex-wrap: wrap; gap: .3rem; }
+.pf-community-tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .66rem; padding: .15rem .5rem;
+  border-radius: 3px; background: rgba(100,255,218,.06);
+  color: #6a7384;
+}
+
+/* ------------------------------------------------------------------ */
+/*  EDUCATION  (Section 07)                                           */
+/* ------------------------------------------------------------------ */
+.pf-edu-list { list-style: none; }
+.pf-edu-item {
+  display: grid; grid-template-columns: 120px 1fr;
+  gap: 1.5rem; padding: 1.4rem 0;
+  border-bottom: 1px solid rgba(100,255,218,.06);
+}
+.pf-edu-item:last-child { border-bottom: none; }
+.pf-edu-year {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .82rem; color: #64ffda; padding-top: .15rem;
+}
+.pf-edu-degree {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.1rem; font-weight: 500; color: #e8ecf1;
+  margin-bottom: .15rem;
+}
+.pf-edu-school { font-size: .86rem; color: #8892a4; }
+.pf-edu-detail { font-size: .82rem; color: #6a7384; margin-top: .2rem; }
+
+/* ------------------------------------------------------------------ */
+/*  CONTACT                                                           */
+/* ------------------------------------------------------------------ */
+.pf-contact {
+  padding: 6rem 0 4rem;
+}
+.pf-contact-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 3rem;
+  align-items: start;
+}
+.pf-contact-headline {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(1.8rem, 3.4vw, 2.4rem);
+  font-weight: 500; font-style: italic; color: #64ffda;
+  line-height: 1.2; margin-bottom: 1rem;
+}
+.pf-contact-sub {
+  font-size: .9rem; color: #8892a4; line-height: 1.7;
+}
+.pf-contact-links { list-style: none; }
+.pf-contact-link {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1rem 0;
+  border-bottom: 1px solid rgba(100,255,218,.06);
+  transition: padding-left .2s;
+}
+.pf-contact-link:hover { padding-left: .4rem; }
+.pf-contact-link:last-child { border-bottom: none; }
+.pf-contact-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: .72rem; font-weight: 500; letter-spacing: 1px;
+  text-transform: uppercase; color: #6a7384;
+  min-width: 80px;
+}
+.pf-contact-value { font-size: .88rem; color: #e8ecf1; }
+.pf-contact-arrow { color: #6a7384; transition: color .2s, transform .2s; }
+.pf-contact-link:hover .pf-contact-arrow {
+  color: #64ffda; transform: translate(3px, -3px);
+}
+
+/* ------------------------------------------------------------------ */
+/*  FOOTER                                                            */
+/* ------------------------------------------------------------------ */
+.pf-footer {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 2rem 0; margin-top: 2rem;
+  border-top: 1px solid rgba(100,255,218,.06);
+  font-size: .78rem; color: #6a7384;
+}
+.pf-footer-domain {
+  font-family: 'IBM Plex Mono', monospace; color: #6a7384;
+}
+
+/* ------------------------------------------------------------------ */
+/*  RESPONSIVE                                                        */
+/* ------------------------------------------------------------------ */
+@media (max-width: 900px) {
+  .pf-work-grid,
+  .pf-community-grid { grid-template-columns: 1fr; }
+  .pf-research-grid  { grid-template-columns: 1fr; gap: 2rem; }
+  .pf-contact-grid   { grid-template-columns: 1fr; gap: 2rem; }
+  .pf-metrics        { grid-template-columns: repeat(2, 1fr); }
+  .pf-metric:nth-child(3) { border-left: none; }
+  .pf-metric:nth-child(n+3) { border-top: 1px solid rgba(100,255,218,.1); }
+}
+
+@media (max-width: 768px) {
+  .pf-nav-links { display: none; position: absolute; top: 64px; left: 0; right: 0;
+    background: rgba(8,12,18,.97); flex-direction: column; padding: 1.2rem 1.5rem;
+    border-bottom: 1px solid rgba(100,255,218,.07); gap: .7rem;
+  }
+  .pf-nav-links.open { display: flex; }
+  .pf-nav-toggle { display: block; }
+
+  .pf-hero-headline { font-size: clamp(1.8rem, 7vw, 2.6rem); }
+
+  .pf-recog-item { grid-template-columns: 60px 1fr; }
+  .pf-recog-org  { grid-column: 2; text-align: left; font-size: .78rem; }
+
+  .pf-writing-item { grid-template-columns: 36px 1fr; }
+  .pf-writing-arrow { display: none; }
+
+  .pf-edu-item { grid-template-columns: 1fr; gap: .3rem; }
+}
+
+@media (max-width: 480px) {
+  body { font-size: 14px; }
+  .pf-metrics { grid-template-columns: 1fr 1fr; }
+  .pf-hero { min-height: auto; padding-top: 6rem; padding-bottom: 2rem; }
+  .pf-section { padding: 4rem 0 1.5rem; }
+}
+
+
+/* ── SPA view management — JS controls via style.display ── */
+#blog-view, #post-view { display: none; }
+
+/* ── Blog listing ── */
+.pf-blog-header { padding: 6rem 0 2rem; }
+.pf-blog-title {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(2rem,4vw,3rem); font-weight:500; color:#e8ecf1;
+  margin-bottom:.5rem;
+}
+.pf-blog-back, .pf-post-back {
+  display:inline-flex; align-items:center; gap:.4rem;
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.75rem; color:#64ffda; letter-spacing:.5px;
+  margin-bottom:2rem; transition:opacity .2s; cursor:pointer;
+  text-decoration:none;
+}
+.pf-blog-back:hover, .pf-post-back:hover { opacity:.7; }
+.pf-blog-search-row { display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1.5rem; }
+.pf-blog-search {
+  flex:1; min-width:200px;
+  background:rgba(255,255,255,.04); border:1px solid rgba(100,255,218,.12);
+  border-radius:4px; padding:.55rem 1rem;
+  color:#e8ecf1; font-family:'IBM Plex Sans',sans-serif; font-size:.9rem;
+  outline:none; transition:border-color .2s;
+}
+.pf-blog-search::placeholder { color:#6a7384; }
+.pf-blog-search:focus { border-color:rgba(100,255,218,.35); }
+.pf-blog-filter-row { display:flex; gap:.4rem; flex-wrap:wrap; margin-bottom:2rem; }
+.pf-blog-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.68rem; padding:.25rem .7rem;
+  border:1px solid rgba(100,255,218,.15); border-radius:20px;
+  color:#8892a4; cursor:pointer; transition:all .18s; background:none;
+}
+.pf-blog-tag:hover, .pf-blog-tag.active { border-color:#64ffda; color:#64ffda; }
+.pf-blog-grid {
+  display:grid; grid-template-columns:1fr 1fr; gap:1px;
+  background:rgba(100,255,218,.06);
+  border:1px solid rgba(100,255,218,.06);
+  border-radius:6px; overflow:hidden; margin-bottom:4rem;
+}
+.pf-blog-card {
+  background:#0c1018; padding:1.6rem 1.6rem;
+  transition:background .2s; cursor:pointer;
+  display:flex; flex-direction:column; gap:.5rem;
+}
+.pf-blog-card:hover { background:#111620; }
+.pf-blog-card-date {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.7rem; color:#6a7384;
+}
+.pf-blog-card-title {
+  font-family:'Cormorant Garamond',serif;
+  font-size:1.1rem; font-weight:500; color:#e8ecf1; line-height:1.3;
+}
+.pf-blog-card-desc { font-size:.82rem; color:#8892a4; line-height:1.6; flex:1; }
+.pf-blog-card-tags { display:flex; flex-wrap:wrap; gap:.3rem; margin-top:.3rem; }
+.pf-blog-card-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.64rem; padding:.15rem .45rem; border-radius:3px;
+  background:rgba(100,255,218,.06); color:#6a7384;
+}
+.pf-blog-empty {
+  grid-column:1/-1; padding:3rem;
+  text-align:center; color:#6a7384; font-size:.9rem;
+}
+
+/* ── Post view ── */
+.pf-post-header { padding:6rem 0 2rem; }
+.pf-post-meta { display:flex; gap:1rem; align-items:center; margin-bottom:1.2rem; flex-wrap:wrap; }
+.pf-post-date { font-family:'IBM Plex Mono',monospace; font-size:.75rem; color:#6a7384; }
+.pf-post-tags { display:flex; gap:.35rem; flex-wrap:wrap; }
+.pf-post-tag {
+  font-family:'IBM Plex Mono',monospace;
+  font-size:.66rem; padding:.15rem .5rem; border-radius:3px;
+  background:rgba(100,255,218,.06); color:#8892a4;
+}
+.pf-post-title {
+  font-family:'Cormorant Garamond',serif;
+  font-size:clamp(1.8rem,3.5vw,2.8rem);
+  font-weight:500; color:#e8ecf1; line-height:1.2; margin-bottom:2.5rem;
+}
+.pf-post-content {
+  max-width:720px;
+  font-size:.95rem; line-height:1.78; color:#9aa0b0; margin-bottom:4rem;
+}
+.pf-post-content h1,.pf-post-content h2,.pf-post-content h3 {
+  font-family:'Cormorant Garamond',serif; color:#e8ecf1;
+  margin:2rem 0 .8rem; font-weight:500;
+}
+.pf-post-content h2 { font-size:1.5rem; }
+.pf-post-content h3 { font-size:1.2rem; }
+.pf-post-content p { margin-bottom:1.1rem; }
+.pf-post-content ul,.pf-post-content ol { margin:0 0 1.1rem 1.4rem; }
+.pf-post-content li { margin-bottom:.4rem; }
+.pf-post-content strong { color:#cdd3df; }
+.pf-post-content code {
+  font-family:'IBM Plex Mono',monospace; font-size:.85em;
+  background:rgba(100,255,218,.06); padding:.15rem .4rem;
+  border-radius:3px; color:#64ffda;
+}
+.pf-post-content pre {
+  background:rgba(0,0,0,.3); border:1px solid rgba(100,255,218,.08);
+  border-radius:6px; padding:1.2rem 1.4rem; overflow-x:auto; margin-bottom:1.2rem;
+}
+.pf-post-content pre code { background:none; padding:0; border-radius:0; color:#9aa0b0; }
+.pf-post-content blockquote {
+  border-left:2px solid #64ffda; padding-left:1rem;
+  color:#6a7384; font-style:italic; margin:1.2rem 0;
+}
+.pf-post-content a { color:#64ffda; }
+.pf-post-content hr { border:none; border-top:1px solid rgba(100,255,218,.1); margin:2rem 0; }
+.pf-post-loading {
+  text-align:center; padding:3rem; color:#6a7384;
+  font-family:'IBM Plex Mono',monospace; font-size:.85rem;
+}
+
+@media (max-width:768px) {
+  .pf-blog-grid { grid-template-columns:1fr; }
+}
+
+  </style>
 </head>
 <body>
 
-<!-- ============================================================= -->
-<!--  NAV                                                           -->
-<!-- ============================================================= -->
 <nav class="pf-nav">
   <a href="#" class="pf-nav-brand">Dr. Soumya <span class="accent">Maity</span></a>
   <button class="pf-nav-toggle" aria-label="Toggle navigation">&#9776;</button>
@@ -29,34 +672,25 @@
     <li><a href="#writing">Writing</a></li>
     <li><a href="#research">Research</a></li>
     <li><a href="#speaking">Speaking</a></li>
+    <li><a href="#blog">Blog</a></li>
     <li><a href="#contact" class="nav-contact">Contact</a></li>
   </ul>
 </nav>
 
-<!-- ============================================================= -->
-<!--  HERO                                                          -->
-<!-- ============================================================= -->
+<!-- ═══════════════════════════════════════════════════════════
+     HOME VIEW  (default — all sections scroll normally)
+═══════════════════════════════════════════════════════════ -->
+<div id="home-view" class="spa-view">
+
 <header class="pf-hero pf-wrap" id="hero" data-nav>
-  <div class="pf-hero-eyebrow hero-anim hero-anim-1">BusinessWorld Security 40under40 &middot; 2024</div>
-
-  <h1 class="pf-hero-headline hero-anim hero-anim-2">
-    Building the security foundations that <em>AI-era</em> products run on
-  </h1>
-
-  <p class="pf-hero-sub hero-anim hero-anim-3">
-    Distinguished product security architect at Dell Technologies. Leading AI
-    security governance, post-quantum cryptography readiness, and open-source trust
-    at enterprise scale&nbsp;&mdash; across 10,000+ products and 50,000+ developers.<br>
-    PhD, IIT Kharagpur &middot; 4&nbsp;US Patents &middot; Professor of Practice, REVA University.
-  </p>
-
+  <div class="pf-hero-eyebrow hero-anim hero-anim-1">BusinessWorld Security 40under40 · 2024</div>
+  <h1 class="pf-hero-headline hero-anim hero-anim-2">Building the security foundations that <em>AI-era</em> products run on</h1>
+  <p class="pf-hero-sub hero-anim hero-anim-3">Distinguished product security architect at Dell Technologies. Leading AI security governance, post-quantum cryptography readiness, and open-source trust at enterprise scale &mdash; across 10,000+ products and 50,000+ developers. PhD, IIT Kharagpur &middot; 4 US Patents &middot; Professor of Practice, REVA University.</p>
   <div class="pf-hero-buttons hero-anim hero-anim-4">
     <a href="files/SMAITY_short_CV.pdf" class="pf-btn pf-btn-fill" target="_blank" rel="noopener">Download CV</a>
     <a href="#writing" class="pf-btn pf-btn-ghost">Read my writing</a>
     <a href="#contact" class="pf-btn pf-btn-ghost">Get in touch</a>
   </div>
-
-  <!-- Metrics -->
   <div class="pf-metrics hero-anim hero-anim-5">
     <div class="pf-metric">
       <div class="pf-metric-value"><span data-count="16">0</span><span class="counter-suffix">+</span></div>
@@ -77,28 +711,24 @@
   </div>
 </header>
 
-<!-- ============================================================= -->
-<!--  SECTION 01 — What I am building now                          -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="work" data-nav>
-  <div class="pf-section-label">01 &mdash; Current focus</div>
+  <div class="pf-section-label">01 — Current focus</div>
   <h2 class="pf-section-title">What I am building now</h2>
-
   <div class="pf-work-grid">
     <div class="pf-work-card featured">
       <div class="pf-work-card-label">AI Security</div>
       <h3>Enterprise AI Threat Library</h3>
-      <p>Building a comprehensive catalogue of AI abuse cases and SDL-phase mitigations&nbsp;&mdash; the foundational framework for securing generative AI products at enterprise scale. Includes adversarial prompt threats, model inversion, data poisoning, and supply-chain attacks on model weights.</p>
+      <p>Building a comprehensive catalogue of AI abuse cases and SDL-phase mitigations &mdash; the foundational framework for securing generative AI products at enterprise scale. Includes adversarial prompt threats, model inversion, data poisoning, and supply-chain attacks on model weights.</p>
     </div>
     <div class="pf-work-card featured">
       <div class="pf-work-card-label">Post-Quantum Cryptography</div>
       <h3>PQC Readiness for Dell Products</h3>
-      <p>Leading the cryptographic migration study for CRYSTALS-Kyber (FIPS-203) and CRYSTALS-Dilithium (FIPS-204/205) across the Dell product portfolio&nbsp;&mdash; ahead of the NIST mandate. Includes cryptographic asset inventory, hybrid transition planning, and CBOM creation.</p>
+      <p>Leading the cryptographic migration study for CRYSTALS-Kyber (FIPS-203) and CRYSTALS-Dilithium (FIPS-204/205) across the Dell product portfolio &mdash; ahead of the NIST mandate. Includes cryptographic asset inventory, hybrid transition planning, and CBOM creation.</p>
     </div>
     <div class="pf-work-card">
       <div class="pf-work-card-label">Supply Chain Security</div>
       <h3>Open-Source Trustworthiness Model</h3>
-      <p>A dynamic risk model for OSS components that goes beyond point-in-time CVE scanning: fix velocity, issue-open ratios, CI/CD security gate quality, and update cadence as first-class trust signals. Operationalized as automated quality gates across Dell&rsquo;s product pipelines.</p>
+      <p>A dynamic risk model for OSS components that goes beyond point-in-time CVE scanning: fix velocity, issue-open ratios, CI/CD security gate quality, and update cadence as first-class trust signals. Operationalized as automated quality gates across Dell's product pipelines.</p>
     </div>
     <div class="pf-work-card">
       <div class="pf-work-card-label">Governance &amp; Compliance</div>
@@ -108,13 +738,9 @@
   </div>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 02 — Recognition                                     -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="recognition" data-nav>
-  <div class="pf-section-label">02 &mdash; Recognition</div>
+  <div class="pf-section-label">02 — Recognition</div>
   <h2 class="pf-section-title">Recognition</h2>
-
   <ul class="pf-recog-list">
     <li class="pf-recog-item">
       <span class="pf-recog-year">2024</span>
@@ -128,7 +754,7 @@
     </li>
     <li class="pf-recog-item">
       <span class="pf-recog-year">2021</span>
-      <span class="pf-recog-name">Game Changer Award&nbsp;&mdash; 4&times; recipient</span>
+      <span class="pf-recog-name">Game Changer Award — 4× recipient</span>
       <span class="pf-recog-org">Dell Technologies</span>
     </li>
     <li class="pf-recog-item">
@@ -144,188 +770,122 @@
   </ul>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 03 — Writing                                         -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="writing" data-nav>
   <div class="pf-section-label">03 &mdash; Writing</div>
   <h2 class="pf-section-title">Writing</h2>
-
   <ul class="pf-writing-list">
     <li class="pf-writing-item">
       <span class="pf-writing-num">01</span>
       <div>
-        <div class="pf-writing-title">Building an AI Threat Library for enterprise products&nbsp;&mdash; what we learned</div>
-        <div class="pf-writing-desc">Abuse cases, SDL-phase mapping, and why traditional threat modeling frameworks fail when applied to generative AI systems. A practitioner&rsquo;s account from building this at Dell scale.</div>
-        <div class="pf-writing-pills">
-          <span class="pf-pill pf-pill-soon">Coming soon</span>
-          <span class="pf-pill">AI Security</span>
-          <span class="pf-pill">Threat Modeling</span>
-        </div>
+        <div class="pf-writing-title">Building an AI Threat Library for enterprise products &mdash; what we learned</div>
+        <div class="pf-writing-desc">Abuse cases, SDL-phase mapping, and why traditional threat modeling frameworks fail when applied to generative AI systems. A practitioner's account from building this at Dell scale.</div>
+        <div class="pf-writing-pills"><span class="pf-pill">AI Security</span><span class="pf-pill">Threat Modeling</span><span class="pf-pill pf-pill-soon">Coming soon</span></div>
       </div>
       <span class="pf-writing-arrow">&nearr;</span>
     </li>
     <li class="pf-writing-item">
       <span class="pf-writing-num">02</span>
       <div>
-        <div class="pf-writing-title">Preparing enterprise products for FIPS-203/204/205&nbsp;&mdash; a practitioner&rsquo;s guide</div>
+        <div class="pf-writing-title">Preparing enterprise products for FIPS-203/204/205 &mdash; a practitioner's guide</div>
         <div class="pf-writing-desc">What post-quantum cryptography readiness actually looks like at scale: cryptographic asset inventory, migration sequencing, and navigating the hybrid classical-quantum transition period.</div>
-        <div class="pf-writing-pills">
-          <span class="pf-pill pf-pill-soon">Coming soon</span>
-          <span class="pf-pill">Post-Quantum</span>
-          <span class="pf-pill">Cryptography</span>
-        </div>
+        <div class="pf-writing-pills"><span class="pf-pill">Post-Quantum</span><span class="pf-pill">Cryptography</span><span class="pf-pill pf-pill-soon">Coming soon</span></div>
       </div>
       <span class="pf-writing-arrow">&nearr;</span>
     </li>
     <li class="pf-writing-item">
       <span class="pf-writing-num">03</span>
       <div>
-        <div class="pf-writing-title">Why CVE scanning is not enough&nbsp;&mdash; rethinking open-source trustworthiness</div>
+        <div class="pf-writing-title">Why CVE scanning is not enough &mdash; rethinking open-source trustworthiness</div>
         <div class="pf-writing-desc">The case for dynamic trust signals: fix velocity, issue ratios, and developer security hygiene as first-class metrics for evaluating OSS dependency risk.</div>
-        <div class="pf-writing-pills">
-          <span class="pf-pill">Supply Chain</span>
-          <span class="pf-pill">OSS Security</span>
-        </div>
+        <div class="pf-writing-pills"><span class="pf-pill">Supply Chain</span><span class="pf-pill">OSS Security</span></div>
       </div>
       <span class="pf-writing-arrow">&nearr;</span>
     </li>
     <li class="pf-writing-item">
       <span class="pf-writing-num">04</span>
       <div>
-        <div class="pf-writing-title">The DPDP Act and product security&nbsp;&mdash; what engineering teams are missing</div>
-        <div class="pf-writing-desc">The gap between legal compliance and technical implementation of India&rsquo;s Digital Personal Data Protection Act&nbsp;&mdash; and why security architects need to own both.</div>
-        <div class="pf-writing-pills">
-          <span class="pf-pill">Cyber Law</span>
-          <span class="pf-pill">Compliance</span>
-        </div>
+        <div class="pf-writing-title">The DPDP Act and product security &mdash; what engineering teams are missing</div>
+        <div class="pf-writing-desc">The gap between legal compliance and technical implementation of India's Digital Personal Data Protection Act &mdash; and why security architects need to own both.</div>
+        <div class="pf-writing-pills"><span class="pf-pill">Cyber Law</span><span class="pf-pill">Compliance</span></div>
       </div>
       <span class="pf-writing-arrow">&nearr;</span>
     </li>
   </ul>
-
-  <div style="margin-top:2rem; text-align:center;">
-    <a href="blog.html" class="pf-btn pf-btn-ghost">View all blog posts &rarr;</a>
+  <div style="margin-top:2rem;text-align:center">
+    <a href="#blog" class="pf-btn pf-btn-ghost" id="view-all-blog">View all blog posts &rarr;</a>
   </div>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 04 — Research & Patents                              -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="research" data-nav>
   <div class="pf-section-label">04 &mdash; Research &amp; Patents</div>
   <h2 class="pf-section-title">Research &amp; Patents</h2>
-
   <div class="pf-research-grid">
     <div class="pf-research-col">
       <h3>US Patents</h3>
-      <ul class="pf-research-list">
-        <li>Method and system for establishing trust between nodes in a network based on recommendations</li>
-        <li>System for query-based interactive risk model analysis for secure software development</li>
-        <li>Patent in product security (details on request)</li>
-        <li>Patent in product security (details on request)</li>
-      </ul>
+<ul class="pf-research-list">
+<li>Method and system for establishing trust between nodes in a network based on recommendations</li>
+<li>System for query-based interactive risk model analysis for secure software development</li>
+<li>Patent in product security (details on request)</li>
+<li>Patent in product security (details on request)</li>
+</ul>
     </div>
     <div class="pf-research-col">
       <h3>Selected Publications</h3>
-      <ul class="pf-research-list">
-        <li>Threat Modeling of Cloud-Based Homomorphic Encryption&nbsp;&mdash; IJCIS 2020</li>
-        <li>PoliCon: Policy Conciliation for Heterogeneous MANETs&nbsp;&mdash; Wiley SCN 2015</li>
-        <li>FINSAT: Formal Network Security Configuration Analysis&nbsp;&mdash; IET Networks 2014</li>
-        <li>Conflict Resolution in Co-allied MANET&nbsp;&mdash; ICDCN / Springer 2015</li>
-      </ul>
-      <div class="pf-research-more">+ 16 further IEEE/ACM papers &amp; 1 book chapter</div>
+<ul class="pf-research-list">
+<li>Threat Modeling of Cloud-Based Homomorphic Encryption &mdash; IJCIS 2020</li>
+<li>PoliCon: Policy Conciliation for Heterogeneous MANETs &mdash; Wiley SCN 2015</li>
+<li>FINSAT: Formal Network Security Configuration Analysis &mdash; IET Networks 2014</li>
+<li>Conflict Resolution in Co-allied MANET &mdash; ICDCN / Springer 2015</li>
+</ul>
+<p class="pf-research-more"><em>+ 16 further IEEE/ACM papers & 1 book chapter</em></p>
     </div>
   </div>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 05 — Speaking                                        -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="speaking" data-nav>
   <div class="pf-section-label">05 &mdash; Speaking</div>
   <h2 class="pf-section-title">Speaking</h2>
-
   <div class="pf-speaking-number">100+</div>
   <div class="pf-speaking-label">national and global security forums, conferences, and universities</div>
-
   <div class="pf-tag-cloud">
-    <span class="pf-tag-pill">OWASP</span>
-    <span class="pf-tag-pill">DSCI</span>
-    <span class="pf-tag-pill">BSIDES</span>
-    <span class="pf-tag-pill">IEEE Forums</span>
-    <span class="pf-tag-pill">SANS Community</span>
-    <span class="pf-tag-pill">Nullcon</span>
-    <span class="pf-tag-pill">ClubHack</span>
-    <span class="pf-tag-pill">IIT Guest Lectures</span>
-    <span class="pf-tag-pill">Industry Panels</span>
-    <span class="pf-tag-pill">University Forums</span>
+    <span class="pf-tag-pill">OWASP</span><span class="pf-tag-pill">DSCI</span><span class="pf-tag-pill">BSIDES</span><span class="pf-tag-pill">IEEE Forums</span><span class="pf-tag-pill">SANS Community</span><span class="pf-tag-pill">Nullcon</span><span class="pf-tag-pill">ClubHack</span><span class="pf-tag-pill">IIT Guest Lectures</span><span class="pf-tag-pill">Industry Panels</span><span class="pf-tag-pill">University Forums</span>
   </div>
-
   <p class="pf-speaking-note">Available for keynotes, panels, and advisory conversations on AI security, post-quantum cryptography, and the techno-legal dimensions of cyber governance.</p>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 06 — Community & Service                             -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="community" data-nav>
   <div class="pf-section-label">06 &mdash; Community &amp; Service</div>
   <h2 class="pf-section-title">Community &amp; Service</h2>
-
   <div class="pf-community-grid">
     <div class="pf-community-card">
       <h3>Cyber Vidhi Sangam</h3>
       <p>Founding trustee of a non-profit techno-legal forum making cyber law accessible to ordinary citizens and providing direct support to cybercrime victims. Bridging the gap between legal systems and technology for people who need it most.</p>
-      <div class="pf-community-tags">
-        <span class="pf-community-tag">Founding trustee</span>
-        <span class="pf-community-tag">Cyber law</span>
-        <span class="pf-community-tag">Non-profit</span>
-      </div>
+      <div class="pf-community-tags"><span class="pf-community-tag">Founding trustee</span><span class="pf-community-tag">Cyber law</span><span class="pf-community-tag">Non-profit</span></div>
     </div>
     <div class="pf-community-card">
       <h3>Professor of Practice</h3>
       <p>Teaching cryptography, security engineering, DevSecOps, and the techno-legal dimensions of AI and data protection law at REVA University, Bengaluru. Designing and delivering courses for executive M.Tech programmes.</p>
-      <div class="pf-community-tags">
-        <span class="pf-community-tag">REVA University</span>
-        <span class="pf-community-tag">Cryptography</span>
-        <span class="pf-community-tag">DevSecOps</span>
-        <span class="pf-community-tag">Cyber law</span>
-      </div>
+      <div class="pf-community-tags"><span class="pf-community-tag">REVA University</span><span class="pf-community-tag">Cryptography</span><span class="pf-community-tag">DevSecOps</span><span class="pf-community-tag">Cyber law</span></div>
     </div>
     <div class="pf-community-card">
       <h3>Industry Memberships</h3>
-      <p>Active member and working group participant across the global security community&nbsp;&mdash; contributing to standards, frameworks, and the next generation of security practitioners.</p>
-      <div class="pf-community-tags">
-        <span class="pf-community-tag">OWASP</span>
-        <span class="pf-community-tag">IEEE</span>
-        <span class="pf-community-tag">SANS</span>
-        <span class="pf-community-tag">Safecode</span>
-        <span class="pf-community-tag">DSCI</span>
-        <span class="pf-community-tag">BSIDES</span>
-      </div>
+      <p>Active member and working group participant across the global security community &mdash; contributing to standards, frameworks, and the next generation of security practitioners.</p>
+      <div class="pf-community-tags"><span class="pf-community-tag">OWASP</span><span class="pf-community-tag">IEEE</span><span class="pf-community-tag">SANS</span><span class="pf-community-tag">Safecode</span><span class="pf-community-tag">DSCI</span><span class="pf-community-tag">BSIDES</span></div>
     </div>
     <div class="pf-community-card">
       <h3>Working Groups</h3>
       <p>Contributing member of standards-setting bodies shaping how the industry measures, communicates, and responds to security risk in the post-quantum and AI era.</p>
-      <div class="pf-community-tags">
-        <span class="pf-community-tag">CVSS WG</span>
-        <span class="pf-community-tag">PQC WG</span>
-        <span class="pf-community-tag">Pan-Dell Patent Review</span>
-      </div>
+      <div class="pf-community-tags"><span class="pf-community-tag">CVSS WG</span><span class="pf-community-tag">PQC WG</span><span class="pf-community-tag">Pan-Dell Patent Review</span></div>
     </div>
   </div>
 </section>
 
-<!-- ============================================================= -->
-<!--  SECTION 07 — Education                                       -->
-<!-- ============================================================= -->
 <section class="pf-section pf-wrap reveal" id="education" data-nav>
   <div class="pf-section-label">07 &mdash; Education</div>
   <h2 class="pf-section-title">Education</h2>
-
   <ul class="pf-edu-list">
     <li class="pf-edu-item">
-      <span class="pf-edu-year">2009 &ndash; 2014</span>
+      <span class="pf-edu-year">2009&ndash;2014</span>
       <div>
         <div class="pf-edu-degree">PhD, Information Security</div>
         <div class="pf-edu-school">Indian Institute of Technology Kharagpur</div>
@@ -333,29 +893,26 @@
       </div>
     </li>
     <li class="pf-edu-item">
-      <span class="pf-edu-year">2024 &ndash; 2026</span>
+      <span class="pf-edu-year">2024&ndash;2026</span>
       <div>
         <div class="pf-edu-degree">PGD, Cyber Law &amp; Cyber Forensics</div>
         <div class="pf-edu-school">National Law School of India University (NLSIU), Bengaluru</div>
       </div>
     </li>
     <li class="pf-edu-item">
-      <span class="pf-edu-year">2004 &ndash; 2008</span>
+      <span class="pf-edu-year">2004&ndash;2008</span>
       <div>
         <div class="pf-edu-degree">B.Tech, Computer Science &amp; Engineering</div>
-        <div class="pf-edu-school">Institute of Engineering &amp; Management, Kolkata &middot; CGPA 8.6/10</div>
+        <div class="pf-edu-school">Institute of Engineering &amp; Management, Kolkata · CGPA 8.6/10</div>
       </div>
     </li>
   </ul>
 </section>
 
-<!-- ============================================================= -->
-<!--  CONTACT                                                       -->
-<!-- ============================================================= -->
 <section class="pf-contact pf-wrap reveal" id="contact" data-nav>
   <div class="pf-contact-grid">
     <div>
-      <h2 class="pf-contact-headline">Let&rsquo;s build something secure together</h2>
+      <h2 class="pf-contact-headline">Let's build something secure together</h2>
       <p class="pf-contact-sub">Open to conversations about AI security leadership, advisory roles, board-level security consulting, and speaking engagements. Always happy to connect with fellow researchers and practitioners.</p>
     </div>
     <ul class="pf-contact-links">
@@ -381,7 +938,7 @@
         </a>
       </li>
       <li>
-        <a class="pf-contact-link" href="files/SMAITY_short_CV.pdf" target="_blank" rel="noopener">
+        <a class="pf-contact-link" href="files/SMAITY_short_CV.pdf">
           <span class="pf-contact-type">Resume</span>
           <span class="pf-contact-value">Download full CV (PDF)</span>
           <span class="pf-contact-arrow">&nearr;</span>
@@ -391,14 +948,267 @@
   </div>
 </section>
 
-<!-- ============================================================= -->
-<!--  FOOTER                                                        -->
-<!-- ============================================================= -->
 <footer class="pf-footer pf-wrap">
-  <span>&copy; 2025 Dr. Soumya Maity &middot; Bengaluru, India</span>
+  <span>© 2025 Dr. Soumya Maity · Bengaluru, India</span>
   <span class="pf-footer-domain">smaity.co.in</span>
 </footer>
+</div>
 
-<script src="js/portfolio.js"></script>
+<!-- ═══════════════════════════════════════════════════════════
+     BLOG VIEW  (#blog)
+═══════════════════════════════════════════════════════════ -->
+<div id="blog-view" class="spa-view">
+  <div class="pf-wrap">
+    <div class="pf-blog-header">
+      <a href="#" id="blog-back" class="pf-blog-back">&larr; Back to home</a>
+      <h1 class="pf-blog-title">All Writing</h1>
+      <div class="pf-blog-search-row">
+        <input id="blog-search" class="pf-blog-search" type="search"
+               placeholder="Search 96 posts&hellip;" autocomplete="off">
+      </div>
+      <div id="blog-tag-row" class="pf-blog-filter-row"></div>
+    </div>
+    <div id="blog-cards" class="pf-blog-grid"></div>
+  </div>
+  <footer class="pf-footer pf-wrap">
+  <span>© 2025 Dr. Soumya Maity · Bengaluru, India</span>
+  <span class="pf-footer-domain">smaity.co.in</span>
+</footer>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
+     POST VIEW  (#blog/<slug>)
+═══════════════════════════════════════════════════════════ -->
+<div id="post-view" class="spa-view">
+  <div class="pf-wrap">
+    <div class="pf-post-header">
+      <a href="#" id="post-back" class="pf-post-back">&larr; All posts</a>
+      <div class="pf-post-meta">
+        <span id="post-date" class="pf-post-date"></span>
+        <div id="post-tags" class="pf-post-tags"></div>
+      </div>
+      <h1 id="post-title" class="pf-post-title"></h1>
+    </div>
+    <div id="post-content" class="pf-post-content"></div>
+  </div>
+  <footer class="pf-footer pf-wrap">
+  <span>© 2025 Dr. Soumya Maity · Bengaluru, India</span>
+  <span class="pf-footer-domain">smaity.co.in</span>
+</footer>
+</div>
+
+<script>
+
+// ── Blog manifest (embedded at build time) ──────────────────────────────────
+const BLOG = [{"slug": "Security-information-and-event-management-(SIEM)", "title": "Security Information and Event Management (SIEM)", "date": "2023-04-03", "description": "Security information and event management (SIEM)", "tags": ["Security", "information", "and", "event", "management", "(SIEM)", "InfoSec"]}, {"slug": "Application-security-monitoring", "title": "Application Security Monitoring", "date": "2023-03-27", "description": "Application security monitoring", "tags": ["Application", "security", "monitoring", "InfoSec"]}, {"slug": "Application-security-for-system-administrators", "title": "Application security for system administrators", "date": "2023-03-07", "description": "Application security for system administrators", "tags": ["Application", "security", "for", "system", "administrators", "InfoSec"]}, {"slug": "Embedded-systems-security", "title": "Embedded Systems Security", "date": "2023-02-08", "description": "Embedded systems security", "tags": ["Embedded", "systems", "security", "InfoSec"]}, {"slug": "Software-composition-analysis-(SCA)", "title": "Software Composition Analysis (SCA): A Deep Dive", "date": "2023-01-20", "description": "Software composition analysis (SCA)", "tags": ["Software", "composition", "analysis", "(SCA)", "InfoSec"]}, {"slug": "Application-security-governance", "title": "Application Security Governance", "date": "2023-01-13", "description": "Application security governance", "tags": ["Application", "security", "governance", "InfoSec"]}, {"slug": "Malware", "title": "Malware: The Malicious Software That Threatens Your Devices", "date": "2022-12-13", "description": "Malware", "tags": ["Malware", "InfoSec"]}, {"slug": "Security-engineering", "title": "Security Engineering", "date": "2022-12-06", "description": "Security engineering", "tags": ["Security", "engineering", "InfoSec"]}, {"slug": "In-memory-data-protection", "title": "In-memory data protection: A critical need in today''s world", "date": "2022-12-02", "description": "In-memory data protection", "tags": ["In-memory", "data", "protection", "InfoSec"]}, {"slug": "Privilege-escalation", "title": "Privilege escalation: What it is and how to prevent it", "date": "2022-11-29", "description": "Privilege escalation", "tags": ["Privilege", "escalation", "InfoSec"]}, {"slug": "Security-testing", "title": "Security Testing", "date": "2022-11-15", "description": "Security testing", "tags": ["Security", "testing", "InfoSec"]}, {"slug": "API-security", "title": "API security", "date": "2022-10-13", "description": "API security", "tags": ["API", "security", "InfoSec"]}, {"slug": "Vulnerability-assessment", "title": "Vulnerability Assessment", "date": "2022-10-01", "description": "Vulnerability assessment", "tags": ["Vulnerability", "assessment", "InfoSec"]}, {"slug": "Application-security-for-software-architects", "title": "Application security for software architects", "date": "2022-09-24", "description": "Application security for software architects", "tags": ["Application", "security", "for", "software", "architects", "InfoSec"]}, {"slug": "Application-security-architecture", "title": "Application Security Architecture", "date": "2022-09-18", "description": "Application security architecture", "tags": ["Application", "security", "architecture", "InfoSec"]}, {"slug": "Vulnerability-management", "title": "Vulnerability Management", "date": "2022-09-07", "description": "Vulnerability management", "tags": ["Vulnerability", "management", "InfoSec"]}, {"slug": "Database-security", "title": "Database Security: Keeping Your Data Safe", "date": "2022-08-30", "description": "Database security", "tags": ["Database", "security", "InfoSec"]}, {"slug": "Application-security-culture", "title": "Application Security Culture", "date": "2022-07-29", "description": "Application security culture", "tags": ["Application", "security", "culture", "InfoSec"]}, {"slug": "Identity-and-access-management-(IAM)", "title": "Identity and Access Management (IAM): The Key to Securing Your Organization", "date": "2022-07-22", "description": "Identity and access management (IAM)", "tags": ["Identity", "and", "access", "management", "(IAM)", "InfoSec"]}, {"slug": "Password-management", "title": "Password Management: It''s Not Just About Remembering Your Passwords", "date": "2022-07-21", "description": "Password management", "tags": ["Password", "management", "InfoSec"]}, {"slug": "Input-validation", "title": "Input Validation: The Key to Secure Applications", "date": "2022-07-15", "description": "Input validation", "tags": ["Input", "validation", "InfoSec"]}, {"slug": "Open-web-application-security-project-(OWASP)", "title": "Open Web Application Security Project (OWASP)", "date": "2022-07-13", "description": "Open web application security project (OWASP)", "tags": ["Open", "web", "application", "security", "project", "(OWASP)", "InfoSec"]}, {"slug": "Application-security-education", "title": "Application Security Education", "date": "2022-07-08", "description": "Application security education", "tags": ["Application", "security", "education", "InfoSec"]}, {"slug": "Application-security-for-beginners", "title": "Application security for beginners", "date": "2022-07-02", "description": "Application security for beginners", "tags": ["Application", "security", "for", "beginners", "InfoSec"]}, {"slug": "Application-firewall", "title": "Application Firewalls: Your First Line of Defense", "date": "2022-06-29", "description": "Application firewall", "tags": ["Application", "firewall", "InfoSec"]}, {"slug": "Grey-box-testing", "title": "Grey Box Testing", "date": "2022-05-12", "description": "Grey box testing", "tags": ["Grey", "box", "testing", "InfoSec"]}, {"slug": "Cloud-security", "title": "Cloud Security: Protecting Your Data in the Cloud", "date": "2022-04-30", "description": "Cloud security", "tags": ["Cloud", "security", "InfoSec"]}, {"slug": "Extensible-markup-language-(XML)-injection", "title": "XML Injection: A Dangerous Vulnerability", "date": "2022-03-27", "description": "Extensible markup language (XML) injection", "tags": ["Extensible", "markup", "language", "(XML)", "injection", "InfoSec"]}, {"slug": "Zero-day-attacks", "title": "Zero-Day Attacks", "date": "2022-03-13", "description": "Zero-day attacks", "tags": ["Zero-day", "attacks", "InfoSec"]}, {"slug": "Mobile-application-security", "title": "Mobile Application Security: A Critical Need in Today''s World", "date": "2022-03-03", "description": "Mobile application security", "tags": ["Mobile", "application", "security", "InfoSec"]}, {"slug": "Application-security-for-everyone", "title": "Application security for everyone", "date": "2022-02-25", "description": "Application security for everyone", "tags": ["Application", "security", "for", "everyone", "InfoSec"]}, {"slug": "Network-security-architecture", "title": "Network Security Architecture", "date": "2022-02-19", "description": "Network security architecture", "tags": ["Network", "security", "architecture", "InfoSec"]}, {"slug": "Web-application-firewall-(WAF)", "title": "Web Application Firewall (WAF)", "date": "2022-01-18", "description": "Web application firewall (WAF)", "tags": ["Web", "application", "firewall", "(WAF)", "InfoSec"]}, {"slug": "Web-development-security", "title": "Web Development Security", "date": "2022-01-16", "description": "Web development security", "tags": ["Web", "development", "security", "InfoSec"]}, {"slug": "Application-security-compliance", "title": "Application Security Compliance", "date": "2022-01-07", "description": "Application security compliance", "tags": ["Application", "security", "compliance", "InfoSec"]}, {"slug": "Zero-day-exploit-prevention", "title": "Zero-day exploit prevention", "date": "2022-01-02", "description": "Zero-day exploit prevention", "tags": ["Zero-day", "exploit", "prevention", "InfoSec"]}, {"slug": "Wireless-security-architecture", "title": "Wireless Security Architecture", "date": "2021-12-26", "description": "Wireless security architecture", "tags": ["Wireless", "security", "architecture", "InfoSec"]}, {"slug": "Code-review", "title": "Code Review: A Peer''s Eye View", "date": "2021-11-03", "description": "Code review", "tags": ["Code", "review", "InfoSec"]}, {"slug": "Application-security-weaknesses", "title": "Application Security Weaknesses", "date": "2021-10-27", "description": "Application security weaknesses", "tags": ["Application", "security", "weaknesses", "InfoSec"]}, {"slug": "Integration-testing", "title": "Integration Testing: The Next Step in Software Testing", "date": "2021-10-06", "description": "Integration testing", "tags": ["Integration", "testing", "InfoSec"]}, {"slug": "Data-loss-prevention-(DLP)", "title": "Data Loss Prevention (DLP): Protecting Your Data", "date": "2021-09-20", "description": "Data loss prevention (DLP)", "tags": ["Data", "loss", "prevention", "(DLP)", "InfoSec"]}, {"slug": "Security-training", "title": "Security Training", "date": "2021-09-02", "description": "Security training", "tags": ["Security", "training", "InfoSec"]}, {"slug": "Object-oriented-programming-(OOP)-injection", "title": "Object-oriented programming (OOP) injection: A threat to your code", "date": "2021-08-31", "description": "Object-oriented programming (OOP) injection", "tags": ["Object-oriented", "programming", "(OOP)", "injection", "InfoSec"]}, {"slug": "Security-operations-center-(SOC)", "title": "Security Operations Center (SOC)", "date": "2021-08-17", "description": "Security operations center (SOC)", "tags": ["Security", "operations", "center", "(SOC)", "InfoSec"]}, {"slug": "Operating-system-security", "title": "Operating System Security", "date": "2021-08-15", "description": "Operating system security", "tags": ["Operating", "system", "security", "InfoSec"]}, {"slug": "Application-programming-interface-(API)-security", "title": "API Security: Protecting Your Data", "date": "2021-08-13", "description": "Application programming interface (API) security", "tags": ["Application", "programming", "interface", "(API)", "security", "InfoSec"]}, {"slug": "Software-development-life-cycle-(SDLC)-security", "title": "Software Development Life Cycle (SDLC) Security", "date": "2021-08-13", "description": "Software development life cycle (SDLC) security", "tags": ["Software", "development", "life", "cycle", "(SDLC)", "security", "InfoSec"]}, {"slug": "Cloud-application-security", "title": "Cloud Application Security", "date": "2021-06-13", "description": "Cloud application security", "tags": ["Cloud", "application", "security", "InfoSec"]}, {"slug": "Application-security-career", "title": "Application Security Career", "date": "2021-06-08", "description": "Application security career", "tags": ["Application", "security", "career", "InfoSec"]}, {"slug": "Enterprise-application-security", "title": "Enterprise Application Security", "date": "2021-05-20", "description": "Enterprise application security", "tags": ["Enterprise", "application", "security", "InfoSec"]}, {"slug": "Application-security-testing-(AST)", "title": "Application Security Testing: Protecting Your Apps", "date": "2021-05-04", "description": "Application security testing (AST)", "tags": ["Application", "security", "testing", "(AST)", "InfoSec"]}, {"slug": "DevSecOps_longer", "title": "DevSecOps: The Future of Security", "date": "2021-04-01", "description": "DevSecOps_longer", "tags": ["DevSecOps_longer", "InfoSec"]}, {"slug": "Security-policy-development", "title": "Security Policy Development", "date": "2021-03-09", "description": "Security policy development", "tags": ["Security", "policy", "development", "InfoSec"]}, {"slug": "Application-security-for-IT-professionals", "title": "Application security for IT professionals", "date": "2021-03-02", "description": "Application security for IT professionals", "tags": ["Application", "security", "for", "IT", "professionals", "InfoSec"]}, {"slug": "Web-application-security-testing-(WAST)", "title": "Web Application Security Testing (WAST)", "date": "2021-02-14", "description": "Web application security testing (WAST)", "tags": ["Web", "application", "security", "testing", "(WAST)", "InfoSec"]}, {"slug": "Static-application-security-testing-(SAST)", "title": "Static Application Security Testing (SAST): A Deep Dive", "date": "2021-01-17", "description": "Static application security testing (SAST)", "tags": ["Static", "application", "security", "testing", "(SAST)", "InfoSec"]}, {"slug": "Physical-security", "title": "Physical Security", "date": "2021-01-16", "description": "Physical security", "tags": ["Physical", "security", "InfoSec"]}, {"slug": "Denial-of-service-(DoS)-prevention", "title": "Denial-of-service (DoS) Prevention", "date": "2021-01-14", "description": "Denial-of-service (DoS) prevention", "tags": ["Denial-of-service", "(DoS)", "prevention", "InfoSec"]}, {"slug": "Attack-surface-management-(ASM)", "title": "Attack Surface Management: Protecting Your Organization from Attack", "date": "2021-01-07", "description": "Attack surface management (ASM)", "tags": ["Attack", "surface", "management", "(ASM)", "InfoSec"]}, {"slug": "Application-security-for-web-developers", "title": "Application security for web developers", "date": "2020-12-12", "description": "Application security for web developers", "tags": ["Application", "security", "for", "web", "developers", "InfoSec"]}, {"slug": "Application-security-for-testers", "title": "Application security for testers", "date": "2020-11-29", "description": "Application security for testers", "tags": ["Application", "security", "for", "testers", "InfoSec"]}, {"slug": "Application-security-for-executives", "title": "Application security for executives", "date": "2020-11-13", "description": "Application security for executives", "tags": ["Application", "security", "for", "executives", "InfoSec"]}, {"slug": "Fuzz-testing", "title": "Fuzz Testing: A Black-Box Testing Technique", "date": "2020-11-02", "description": "Fuzz testing", "tags": ["Fuzz", "testing", "InfoSec"]}, {"slug": "Code-analysis", "title": "Code Analysis: Finding and Fixing Security Vulnerabilities", "date": "2020-09-20", "description": "Code analysis", "tags": ["Code", "analysis", "InfoSec"]}, {"slug": "Mobile-application-security-testing", "title": "Mobile Application Security Testing", "date": "2020-08-02", "description": "Mobile application security testing", "tags": ["Mobile", "application", "security", "testing", "InfoSec"]}, {"slug": "Denial-of-service-(DoS)-attacks", "title": "Denial-of-service (DoS) attacks: A threat to your website", "date": "2020-07-28", "description": "Denial-of-service (DoS) attacks", "tags": ["Denial-of-service", "(DoS)", "attacks", "InfoSec"]}, {"slug": "Security-auditing", "title": "Security Auditing", "date": "2020-07-08", "description": "Security auditing", "tags": ["Security", "auditing", "InfoSec"]}, {"slug": "Security-automation", "title": "Security Automation", "date": "2020-06-21", "description": "Security automation", "tags": ["Security", "automation", "InfoSec"]}, {"slug": "Security-incident-response", "title": "Security Incident Response", "date": "2020-06-08", "description": "Security incident response", "tags": ["Security", "incident", "response", "InfoSec"]}, {"slug": "Cross-site-scripting-(XSS)", "title": "Cross-site Scripting (XSS)", "date": "2020-06-06", "description": "Cross-site scripting (XSS)", "tags": ["Cross-site", "scripting", "(XSS)", "InfoSec"]}, {"slug": "Phishing", "title": "Phishing: The Art of Deception", "date": "2020-05-31", "description": "Phishing", "tags": ["Phishing", "InfoSec"]}, {"slug": "Application-security-metrics", "title": "Application Security Metrics", "date": "2020-05-04", "description": "Application security metrics", "tags": ["Application", "security", "metrics", "InfoSec"]}, {"slug": "Web-application-security", "title": "Web Application Security", "date": "2020-04-30", "description": "Web application security", "tags": ["Web", "application", "security", "InfoSec"]}, {"slug": "Runtime-application-self-protection-(RASP)", "title": "Runtime Application Self-Protection (RASP)", "date": "2020-03-30", "description": "Runtime application self-protection (RASP)", "tags": ["Runtime", "application", "self-protection", "(RASP)", "InfoSec"]}, {"slug": "Application-security-for-managers", "title": "Application security for managers", "date": "2020-02-13", "description": "Application security for managers", "tags": ["Application", "security", "for", "managers", "InfoSec"]}, {"slug": "System-security", "title": "System Security", "date": "2020-02-11", "description": "System security", "tags": ["System", "security", "InfoSec"]}, {"slug": "Risk-assessment", "title": "Risk Assessment", "date": "2020-01-21", "description": "Risk assessment", "tags": ["Risk", "assessment", "InfoSec"]}, {"slug": "Dynamic-application-security-testing-(DAST)", "title": "Dynamic Application Security Testing (DAST): A Hands-On Approach", "date": "2019-12-27", "description": "Dynamic application security testing (DAST)", "tags": ["Dynamic", "application", "security", "testing", "(DAST)", "InfoSec"]}, {"slug": "Application-security-vulnerability-management", "title": "Application Security Vulnerability Management", "date": "2019-10-26", "description": "Application security vulnerability management", "tags": ["Application", "security", "vulnerability", "management", "InfoSec"]}, {"slug": "Application-security-for-software-engineers", "title": "Application security for software engineers", "date": "2019-10-11", "description": "Application security for software engineers", "tags": ["Application", "security", "for", "software", "engineers", "InfoSec"]}, {"slug": "Ransomware", "title": "Ransomware: A growing threat", "date": "2019-09-30", "description": "Ransomware", "tags": ["Ransomware", "InfoSec"]}, {"slug": "Application-security-for-security-professionals", "title": "Application security for security professionals", "date": "2019-09-23", "description": "Application security for security professionals", "tags": ["Application", "security", "for", "security", "professionals", "InfoSec"]}, {"slug": "Application-security-training", "title": "Application Security Training", "date": "2019-09-21", "description": "Application security training", "tags": ["Application", "security", "training", "InfoSec"]}, {"slug": "Container-security", "title": "Container Security: Keeping Your Applications Safe", "date": "2019-09-18", "description": "Container security", "tags": ["Container", "security", "InfoSec"]}, {"slug": "Security-awareness-training", "title": "Security Awareness Training", "date": "2019-09-03", "description": "Security awareness training", "tags": ["Security", "awareness", "training", "InfoSec"]}, {"slug": "Application-security-awareness", "title": "Application Security Awareness", "date": "2019-08-09", "description": "Application security awareness", "tags": ["Application", "security", "awareness", "InfoSec"]}, {"slug": "Secure-coding-practices", "title": "Secure Coding Practices", "date": "2019-08-06", "description": "Secure coding practices", "tags": ["Secure", "coding", "practices", "InfoSec"]}, {"slug": "Application-security-best-practices", "title": "Application Security Best Practices", "date": "2019-07-11", "description": "Application security best practices", "tags": ["Application", "security", "best", "practices", "InfoSec"]}, {"slug": "Zero-trust-security_longer", "title": "Zero Trust Security", "date": "2019-03-27", "description": "Zero trust security_longer", "tags": ["Zero", "trust", "security_longer", "InfoSec"]}, {"slug": "Threat-modeling", "title": "Threat Modeling", "date": "2019-03-19", "description": "Threat modeling", "tags": ["Threat", "modeling", "InfoSec"]}, {"slug": "Browser-security", "title": "Browser Security", "date": "2019-03-08", "description": "Browser security", "tags": ["Browser", "security", "InfoSec"]}, {"slug": "Side-channel-attacks", "title": "Side-Channel Attacks: Sneaking a peek at secrets", "date": "2019-02-16", "description": "Side-channel attacks", "tags": ["Side-channel", "attacks", "InfoSec"]}, {"slug": "Encryption", "title": "Encryption: The Art of Keeping Secrets", "date": "2019-01-22", "description": "Encryption", "tags": ["Encryption", "InfoSec"]}, {"slug": "Threat-intelligence", "title": "Threat Intelligence", "date": "2019-01-18", "description": "Threat intelligence", "tags": ["Threat", "intelligence", "InfoSec"]}, {"slug": "Application-security-for-developers", "title": "Application security for developers", "date": "2019-01-17", "description": "Application security for developers", "tags": ["Application", "security", "for", "developers", "InfoSec"]}, {"slug": "Wireless-security", "title": "Wireless Security", "date": "2019-01-16", "description": "Wireless security", "tags": ["Wireless", "security", "InfoSec"]}];
+
+// ── Utility ─────────────────────────────────────────────────────────────────
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+// ── Nav toggle ───────────────────────────────────────────────────────────────
+const navToggle = document.querySelector('.pf-nav-toggle');
+const navLinks  = document.querySelector('.pf-nav-links');
+navToggle?.addEventListener('click', () => navLinks.classList.toggle('open'));
+document.querySelectorAll('.pf-nav-links a').forEach(a =>
+  a.addEventListener('click', () => navLinks.classList.remove('open')));
+
+// ── Scroll-reveal ────────────────────────────────────────────────────────────
+const revealObs = new IntersectionObserver(
+  entries => entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); }),
+  { threshold: .08 }
+);
+document.querySelectorAll('.reveal').forEach(el => revealObs.observe(el));
+
+// ── Counter animation ────────────────────────────────────────────────────────
+function animateCounter(el) {
+  const target = +el.dataset.count;
+  const dur = 1400;
+  const start = performance.now();
+  const step = now => {
+    const p = Math.min((now - start) / dur, 1);
+    el.textContent = Math.floor(p * p * (3 - 2 * p) * target);
+    if (p < 1) requestAnimationFrame(step); else el.textContent = target;
+  };
+  requestAnimationFrame(step);
+}
+const ctrObs = new IntersectionObserver(entries => {
+  entries.forEach(e => {
+    if (e.isIntersecting) {
+      e.target.querySelectorAll('[data-count]').forEach(animateCounter);
+      ctrObs.unobserve(e.target);
+    }
+  });
+}, { threshold: .3 });
+const metricsEl = document.querySelector('.pf-metrics');
+if (metricsEl) ctrObs.observe(metricsEl);
+
+// ── Active nav highlight ─────────────────────────────────────────────────────
+const navAnchors = document.querySelectorAll('.pf-nav-links a');
+const activeObs  = new IntersectionObserver(entries => {
+  entries.forEach(e => {
+    if (!e.isIntersecting) return;
+    navAnchors.forEach(a => a.classList.remove('active'));
+    const a = document.querySelector(`.pf-nav-links a[href="#${e.target.id}"]`);
+    if (a) a.classList.add('active');
+  });
+}, { rootMargin: '-40% 0px -55% 0px' });
+document.querySelectorAll('[data-nav]').forEach(s => activeObs.observe(s));
+
+// ── SPA router ───────────────────────────────────────────────────────────────
+const VIEW_HOME = document.getElementById('home-view');
+const VIEW_BLOG = document.getElementById('blog-view');
+const VIEW_POST = document.getElementById('post-view');
+
+function showView(name) {
+  VIEW_HOME.style.display = name === 'home' ? '' : 'none';
+  VIEW_BLOG.style.display = name === 'blog' ? '' : 'none';
+  VIEW_POST.style.display = name === 'post' ? '' : 'none';
+  window.scrollTo(0, 0);
+}
+
+function route() {
+  const h = location.hash;
+  if (h.startsWith('#blog/')) {
+    showView('post');
+    loadPost(h.slice(6));
+  } else if (h === '#blog') {
+    showView('blog');
+    renderBlog();
+  } else {
+    showView('home');
+    if (h && h !== '#') {
+      setTimeout(() => {
+        const el = document.querySelector(h);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 50);
+    }
+  }
+}
+
+window.addEventListener('hashchange', route);
+document.addEventListener('DOMContentLoaded', route);
+
+// Intercept "View all blog posts" without changing to a separate page
+document.getElementById('view-all-blog')?.addEventListener('click', e => {
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+});
+
+// ── Blog listing ─────────────────────────────────────────────────────────────
+let activeTag = null;
+let searchQ   = '';
+
+function renderBlog() {
+  const tagRow   = document.getElementById('blog-tag-row');
+  const cards    = document.getElementById('blog-cards');
+  if (!cards) return;
+
+  if (tagRow && !tagRow.dataset.built) {
+    tagRow.dataset.built = '1';
+    const tags = [...new Set(BLOG.flatMap(p => p.tags || []))].sort();
+    tags.forEach(tag => {
+      const btn = document.createElement('button');
+      btn.className = 'pf-blog-tag';
+      btn.textContent = tag;
+      btn.addEventListener('click', () => {
+        activeTag = activeTag === tag ? null : tag;
+        tagRow.querySelectorAll('.pf-blog-tag').forEach(b => b.classList.remove('active'));
+        if (activeTag) btn.classList.add('active');
+        renderCards();
+      });
+      tagRow.appendChild(btn);
+    });
+  }
+  renderCards();
+}
+
+function renderCards() {
+  const cards = document.getElementById('blog-cards');
+  if (!cards) return;
+
+  let posts = BLOG;
+  if (activeTag) posts = posts.filter(p => (p.tags || []).includes(activeTag));
+  if (searchQ)   posts = posts.filter(p =>
+    p.title.toLowerCase().includes(searchQ) ||
+    (p.description || '').toLowerCase().includes(searchQ)
+  );
+
+  if (!posts.length) {
+    cards.innerHTML = '<div class="pf-blog-empty">No posts match your search.</div>';
+    return;
+  }
+
+  cards.innerHTML = posts.map(p => {
+    const d = p.date ? new Date(p.date + 'T00:00:00').toLocaleDateString('en-US', {
+      year: 'numeric', month: 'short', day: 'numeric'
+    }) : '';
+    const tagPills = (p.tags || []).slice(0, 4)
+      .map(t => `<span class="pf-blog-card-tag">${escHtml(t)}</span>`).join('');
+    return `<div class="pf-blog-card" onclick="location.hash='#blog/${encodeURIComponent(p.slug)}'">
+      <div class="pf-blog-card-date">${d}</div>
+      <div class="pf-blog-card-title">${escHtml(p.title)}</div>
+      <div class="pf-blog-card-desc">${escHtml(p.description || '')}</div>
+      <div class="pf-blog-card-tags">${tagPills}</div>
+    </div>`;
+  }).join('');
+}
+
+document.getElementById('blog-search')?.addEventListener('input', e => {
+  searchQ = e.target.value.trim().toLowerCase();
+  renderCards();
+});
+
+document.getElementById('blog-back')?.addEventListener('click', e => {
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+});
+
+// ── Post viewer ───────────────────────────────────────────────────────────────
+async function loadPost(slug) {
+  const slug_dec = decodeURIComponent(slug);
+  const titleEl   = document.getElementById('post-title');
+  const dateEl    = document.getElementById('post-date');
+  const tagsEl    = document.getElementById('post-tags');
+  const contentEl = document.getElementById('post-content');
+
+  if (titleEl)   titleEl.textContent = '';
+  if (contentEl) contentEl.innerHTML = '<div class="pf-post-loading">Loading&hellip;</div>';
+
+  const meta = BLOG.find(p => p.slug === slug_dec);
+  if (meta) {
+    if (titleEl) titleEl.textContent = meta.title;
+    if (dateEl)  dateEl.textContent = meta.date
+      ? new Date(meta.date + 'T00:00:00').toLocaleDateString('en-US', {
+          year: 'numeric', month: 'long', day: 'numeric'
+        })
+      : '';
+    if (tagsEl) tagsEl.innerHTML = (meta.tags || [])
+      .map(t => `<span class="pf-post-tag">${escHtml(t)}</span>`).join('');
+  }
+
+  try {
+    const res = await fetch(`posts/${slug_dec}.md`);
+    if (!res.ok) throw new Error('fetch failed');
+    let md = await res.text();
+    md = md.replace(/^---[\s\S]*?---\n?/, '');
+    contentEl.innerHTML = typeof marked !== 'undefined'
+      ? marked.parse(md)
+      : `<pre>${escHtml(md)}</pre>`;
+  } catch (_) {
+    contentEl.innerHTML = '<p style="color:#6a7384">Could not load this post.</p>';
+  }
+}
+
+document.getElementById('post-back')?.addEventListener('click', e => {
+  e.preventDefault();
+  history.pushState(null, '', '#blog');
+  route();
+});
+
+</script>
 </body>
 </html>

--- a/posts/upcoming.md
+++ b/posts/upcoming.md
@@ -1,0 +1,32 @@
+---
+type: upcoming
+---
+
+<!-- ============================================================
+  UPCOMING WRITING — edit this file to update the "Writing"
+  section on the homepage.
+
+  Format per item:
+    ### Post Title
+    One or two sentence description.
+    [Tag One] [Tag Two] [coming-soon]
+
+  Omit [coming-soon] for published posts that link to a blog entry.
+  Tags are rendered as pills. Order determines numbering (01, 02…).
+============================================================ -->
+
+### Building an AI Threat Library for enterprise products — what we learned
+Abuse cases, SDL-phase mapping, and why traditional threat modeling frameworks fail when applied to generative AI systems. A practitioner's account from building this at Dell scale.
+[AI Security] [Threat Modeling] [coming-soon]
+
+### Preparing enterprise products for FIPS-203/204/205 — a practitioner's guide
+What post-quantum cryptography readiness actually looks like at scale: cryptographic asset inventory, migration sequencing, and navigating the hybrid classical-quantum transition period.
+[Post-Quantum] [Cryptography] [coming-soon]
+
+### Why CVE scanning is not enough — rethinking open-source trustworthiness
+The case for dynamic trust signals: fix velocity, issue ratios, and developer security hygiene as first-class metrics for evaluating OSS dependency risk.
+[Supply Chain] [OSS Security]
+
+### The DPDP Act and product security — what engineering teams are missing
+The gap between legal compliance and technical implementation of India's Digital Personal Data Protection Act — and why security architects need to own both.
+[Cyber Law] [Compliance]


### PR DESCRIPTION
## Summary

- **Markdown-driven content** - every homepage section (hero, work, recognition, research, speaking, community, education, contact) is now in `content/**/*.md`; updating copy only requires editing markdown and running `python3 build.py`
- **Separate folders for work / research / speaking** - `content/work/`, `content/research/`, `content/speaking/` each hold one `.md` file per item, making it trivial to add or reorder entries
- **Upcoming writing placeholder** - `posts/upcoming.md` drives the Writing section using a `### Title / description / [Tag] [coming-soon]` format; add `[coming-soon]` tag to mark unpublished items
- **Single-file SPA** - `build.py` inlines `css/portfolio.css`, embeds the 96-post blog manifest as JSON, and compiles everything into `index.html` with three client-side views:
  - **Home** - all sections scroll as before, content sourced from markdown
  - `#blog` - full listing of all 96 posts with real-time search and tag filter
  - `#blog/<slug>` - individual post fetched on demand, rendered via marked.js
- `generate_manifest.py` patched: excludes `upcoming.md` and fixes list-item regex so tags parse correctly from YAML frontmatter

## Build workflow

`ash
wsl python3 build.py   # outputs index.html (~70 KB, 96 blog posts embedded)
`

## Test plan

- [ ] Open `index.html` locally - all homepage sections render correctly
- [ ] Click **Blog** in nav ? listing appears in-page, 96 posts shown
- [ ] Type in search box ? cards filter live; click a tag pill ? tag filter applies
- [ ] Click a post card ? post loads and renders (marked.js)
- [ ] Click **? All posts** ? returns to blog listing; **? Back to home** ? home
- [ ] Refresh at `#blog/Threat-modeling` ? post loads directly from URL
- [ ] Edit any `content/*.md`, rerun `build.py` ? change appears in `index.html`
- [ ] Edit `posts/upcoming.md`, rerun ? Writing section updates
- [ ] Mobile: hamburger nav works; blog grid collapses to 1 column

?? Generated with [Claude Code](https://claude.com/claude-code)